### PR TITLE
Use OnceCell for Value string_rep

### DIFF
--- a/molt-shell/src/bench.rs
+++ b/molt-shell/src/bench.rs
@@ -102,7 +102,7 @@ pub fn benchmark(interp: &mut Interp, args: &[String]) {
 
     // NEXT, load the benchmark Tcl library
     if let Err(ResultCode::Error(value)) = interp.eval(include_str!("bench.tcl")) {
-        panic!("Error in benchmark Tcl library: {}", &*value.as_string());
+        panic!("Error in benchmark Tcl library: {}", value.as_string());
     }
 
     // NEXT, execute the script.

--- a/molt-shell/src/test_harness.rs
+++ b/molt-shell/src/test_harness.rs
@@ -228,14 +228,14 @@ impl TestCommand {
         let mut ctx = self.ctx.borrow_mut();
 
         // NEXT, get the tes tinfo
-        let mut info = TestInfo::new(&*argv[1].as_string(), &*argv[2].as_string());
+        let mut info = TestInfo::new(argv[1].as_string(), argv[2].as_string());
         let mut iter = argv[3..].iter();
         loop {
             let opt = iter.next();
             if opt.is_none() {
                 break;
             }
-            let opt = &*opt.unwrap().as_string();
+            let opt = opt.unwrap().as_string();
 
             let val = iter.next();
             if val.is_none() {
@@ -243,9 +243,9 @@ impl TestCommand {
                 info.print_helper_error("test command", &format!("missing value for {}", opt));
                 return molt_ok!();
             }
-            let val = &*val.unwrap().as_string();
+            let val = val.unwrap().as_string();
 
-            match opt.as_ref() {
+            match opt {
                 "-setup" => info.setup = val.to_string(),
                 "-body" => info.body = val.to_string(),
                 "-cleanup" => info.cleanup = val.to_string(),
@@ -280,11 +280,11 @@ impl TestCommand {
         let mut ctx = self.ctx.borrow_mut();
 
         // NEXT, get the test info
-        let mut info = TestInfo::new(&*argv[1].as_string(), &*argv[2].as_string());
+        let mut info = TestInfo::new(argv[1].as_string(), argv[2].as_string());
         info.body = argv[3].to_string();
         info.expect = argv[5].to_string();
 
-        let code = &*argv[4].as_string();
+        let code = argv[4].as_string();
 
         info.code = if code == "-ok" {
             Code::Ok
@@ -361,7 +361,7 @@ impl Command for TestCommand {
         molt::check_args(1, argv, 4, 0, "name description args...")?;
 
         // NEXT, see which kind of command it is.
-        let arg = &*argv[3].as_string();
+        let arg = argv[3].as_string();
         if arg.starts_with('-') {
             self.fancy_test(interp, argv)
         } else {

--- a/molt/Cargo.toml
+++ b/molt/Cargo.toml
@@ -11,3 +11,4 @@ readme = "README.md"
 keywords = ["language", "script", "scripting", "tcl"]
 
 [dependencies]
+once_cell = "0.2.4"

--- a/molt/src/commands.rs
+++ b/molt/src/commands.rs
@@ -17,7 +17,7 @@ pub fn cmd_append(interp: &mut Interp, argv: &[Value]) -> MoltResult {
 
     // FIRST, get the value of the variable.  If the variable is undefined,
     // start with the empty string.
-    let var_name = &*argv[1].as_string();
+    let var_name = argv[1].as_string();
 
     let mut new_string: String = interp
         .var(var_name)
@@ -26,7 +26,7 @@ pub fn cmd_append(interp: &mut Interp, argv: &[Value]) -> MoltResult {
 
     // NEXT, append the remaining values to the string.
     for item in &argv[2..] {
-        new_string.push_str(&*item.as_string());
+        new_string.push_str(item.as_string());
     }
 
     // NEXT, save and return the new value.
@@ -80,7 +80,7 @@ pub fn cmd_catch(interp: &mut Interp, argv: &[Value]) -> MoltResult {
     };
 
     if argv.len() == 3 {
-        interp.set_and_return(&*argv[2].as_string(), value);
+        interp.set_and_return(argv[2].as_string(), value);
     }
 
     Ok(Value::from(code))
@@ -202,10 +202,10 @@ pub fn cmd_foreach(interp: &mut Interp, argv: &[Value]) -> MoltResult {
     while i < list.len() {
         for var_name in var_list {
             if i < list.len() {
-                interp.set_var(&*var_name.as_string(), &list[i]);
+                interp.set_var(var_name.as_string(), &list[i]);
                 i += 1;
             } else {
-                interp.set_and_return(&*var_name.as_string(), Value::empty());
+                interp.set_and_return(var_name.as_string(), Value::empty());
             }
         }
 
@@ -233,7 +233,7 @@ pub fn cmd_global(interp: &mut Interp, argv: &[Value]) -> MoltResult {
     if interp.scope_level() > 0 {
         for name in &argv[1..] {
             // TODO: Should upvar take the name as a Value?
-            interp.upvar(0, &*name.as_string());
+            interp.upvar(0, name.as_string());
         }
     }
     molt_ok!()
@@ -271,7 +271,7 @@ pub fn cmd_if(interp: &mut Interp, argv: &[Value]) -> MoltResult {
                 };
             }
             IfWants::ThenBody => {
-                if &*argv[argi].as_string() == "then" {
+                if argv[argi].as_string() == "then" {
                     argi += 1;
                 }
 
@@ -282,7 +282,7 @@ pub fn cmd_if(interp: &mut Interp, argv: &[Value]) -> MoltResult {
                 }
             }
             IfWants::SkipThenClause => {
-                if &*argv[argi].as_string() == "then" {
+                if argv[argi].as_string() == "then" {
                     argi += 1;
                 }
 
@@ -293,7 +293,7 @@ pub fn cmd_if(interp: &mut Interp, argv: &[Value]) -> MoltResult {
                 continue;
             }
             IfWants::ElseClause => {
-                if &*argv[argi].as_string() == "elseif" {
+                if argv[argi].as_string() == "elseif" {
                     wants = IfWants::Expr;
                 } else {
                     wants = IfWants::ElseBody;
@@ -301,7 +301,7 @@ pub fn cmd_if(interp: &mut Interp, argv: &[Value]) -> MoltResult {
                 }
             }
             IfWants::ElseBody => {
-                if &*argv[argi].as_string() == "else" {
+                if argv[argi].as_string() == "else" {
                     argi += 1;
 
                     // If "else" appears, then the else body is required.
@@ -354,7 +354,7 @@ pub fn cmd_incr(interp: &mut Interp, argv: &[Value]) -> MoltResult {
         1
     };
 
-    let var_name = &*argv[1].as_string();
+    let var_name = argv[1].as_string();
 
     let new_value = increment
         + interp
@@ -368,7 +368,7 @@ pub fn cmd_incr(interp: &mut Interp, argv: &[Value]) -> MoltResult {
 /// # info *subcommand* ?*arg*...?
 pub fn cmd_info(interp: &mut Interp, argv: &[Value]) -> MoltResult {
     check_args(1, argv, 2, 0, "subcommand ?arg ...?")?;
-    let subc = Subcommand::find(&INFO_SUBCOMMANDS, &*argv[1].as_string())?;
+    let subc = Subcommand::find(&INFO_SUBCOMMANDS, argv[1].as_string())?;
 
     (subc.1)(interp, argv)
 }
@@ -388,7 +388,7 @@ pub fn cmd_info_commands(interp: &mut Interp, _argv: &[Value]) -> MoltResult {
 pub fn cmd_info_complete(interp: &mut Interp, argv: &[Value]) -> MoltResult {
     check_args(2, argv, 3, 3, "command")?;
 
-    if interp.complete(&*argv[2].as_string()) {
+    if interp.complete(argv[2].as_string()) {
         molt_ok!(true)
     } else {
         molt_ok!(false)
@@ -428,7 +428,7 @@ pub fn cmd_join(_interp: &mut Interp, argv: &[Value]) -> MoltResult {
 pub fn cmd_lappend(interp: &mut Interp, argv: &[Value]) -> MoltResult {
     check_args(1, argv, 2, 0, "varName ?value ...?")?;
 
-    let var_name = &*argv[1].as_string();
+    let var_name = argv[1].as_string();
     let var_result = interp.var(var_name);
 
     let mut list: MoltList = if var_result.is_ok() {
@@ -488,9 +488,9 @@ pub fn cmd_proc(interp: &mut Interp, argv: &[Value]) -> MoltResult {
     check_args(1, argv, 4, 4, "name args body")?;
 
     // FIRST, get the arguments
-    let name = &*argv[1].as_string();
+    let name = argv[1].as_string();
     let args = &*argv[2].as_list()?;
-    let body = &*argv[3].as_string();
+    let body = argv[3].as_string();
 
     // NEXT, validate the argument specs
     for arg in args {
@@ -532,8 +532,8 @@ pub fn cmd_rename(interp: &mut Interp, argv: &[Value]) -> MoltResult {
     check_args(1, argv, 3, 3, "oldName newName")?;
 
     // FIRST, get the arguments
-    let old_name = &*argv[1].as_string();
-    let new_name = &*argv[2].as_string();
+    let old_name = argv[1].as_string();
+    let new_name = argv[2].as_string();
 
     if !interp.has_command(old_name) {
         return molt_err!("can't rename \"{}\": command doesn't exist", old_name);
@@ -581,7 +581,7 @@ pub fn cmd_return(_interp: &mut Interp, argv: &[Value]) -> MoltResult {
 pub fn cmd_set(interp: &mut Interp, argv: &[Value]) -> MoltResult {
     check_args(1, argv, 2, 3, "varName ?newValue?")?;
 
-    let var_name = &*argv[1].as_string();
+    let var_name = argv[1].as_string();
 
     if argv.len() == 3 {
         molt_ok!(interp.set_and_return(var_name, argv[2].clone()))
@@ -596,7 +596,7 @@ pub fn cmd_set(interp: &mut Interp, argv: &[Value]) -> MoltResult {
 pub fn cmd_source(interp: &mut Interp, argv: &[Value]) -> MoltResult {
     check_args(1, argv, 2, 2, "filename")?;
 
-    let filename = &*argv[1].as_string();
+    let filename = argv[1].as_string();
 
     match fs::read_to_string(filename) {
         Ok(script) => interp.eval(&script),
@@ -646,7 +646,7 @@ pub fn cmd_time(interp: &mut Interp, argv: &[Value]) -> MoltResult {
 pub fn cmd_unset(interp: &mut Interp, argv: &[Value]) -> MoltResult {
     check_args(1, argv, 2, 2, "varName")?;
 
-    interp.unset_var(&*argv[1].as_string());
+    interp.unset_var(argv[1].as_string());
 
     molt_ok!()
 }

--- a/molt/src/expr.rs
+++ b/molt/src/expr.rs
@@ -247,7 +247,7 @@ const OP_STRINGS: [&str; 36] = [
 
 /// Evaluates an expression and returns its value.
 pub fn expr(interp: &mut Interp, expr: &Value) -> MoltResult {
-    let value = expr_top_level(interp, &*expr.as_string())?;
+    let value = expr_top_level(interp, expr.as_string())?;
 
     match value.vtype {
         Type::Int => molt_ok!(Value::from(value.int)),
@@ -884,7 +884,7 @@ fn expr_lex(interp: &mut Interp, info: &mut ExprInfo) -> DatumResult {
             } else {
                 // Note: we got a Value, but since it was parsed from a quoted string,
                 // it won't already be numeric.
-                expr_parse_string(&*val.as_string())
+                expr_parse_string(val.as_string())
             }
         }
         Some('{') => {
@@ -898,7 +898,7 @@ fn expr_lex(interp: &mut Interp, info: &mut ExprInfo) -> DatumResult {
             } else {
                 // Note: we got a Value, but since it was parsed from a braced string,
                 // it won't already be numeric.
-                expr_parse_string(&*val.as_string())
+                expr_parse_string(val.as_string())
             }
         }
         Some('(') => {
@@ -1199,7 +1199,7 @@ fn expr_find_func(func_name: &str) -> Result<&'static BuiltinFunc, ResultCode> {
 fn expr_parse_value(value: &Value) -> DatumResult {
     match value.already_number() {
         Some(datum) => Ok(datum),
-        _ => expr_parse_string(&*value.as_string()),
+        _ => expr_parse_string(value.as_string()),
     }
 }
 
@@ -1454,7 +1454,7 @@ mod tests {
 
         let result = expr(&mut interp, &Value::from("[set x foo]"));
         assert!(result.is_ok());
-        assert_eq!(&*result.unwrap().as_string(), "foo");
+        assert_eq!(result.unwrap().as_string(), "foo");
     }
 
     fn near(x: MoltFloat, target: MoltFloat) -> bool {

--- a/molt/src/interp.rs
+++ b/molt/src/interp.rs
@@ -37,7 +37,7 @@
 //!
 //! There are a number of ways to evaluate Molt scripts, all of which return [`MoltResult`]:
 //!
-//! ```
+//! ```ignore
 //! pub type MoltResult = Result<Value, ResultCode>;
 //! ```
 //!

--- a/molt/src/scope.rs
+++ b/molt/src/scope.rs
@@ -184,12 +184,12 @@ mod tests {
         ss.set("a", Value::from("1"));
         let out = ss.get("a");
         assert!(out.is_some());
-        assert_eq!(&*out.unwrap().as_string(), "1");
+        assert_eq!(out.unwrap().as_string(), "1");
 
         ss.set("b", Value::from("2"));
         let out = ss.get("b");
         assert!(out.is_some());
-        assert_eq!(&*out.unwrap().as_string(), "2");
+        assert_eq!(out.unwrap().as_string(), "2");
 
         assert!(ss.get("c").is_none());
     }
@@ -262,13 +262,13 @@ mod tests {
         ss.set("a", Value::from("3"));
         ss.set("b", Value::from("4"));
         ss.set("c", Value::from("5"));
-        assert_eq!(&*ss.get("a").unwrap().as_string(), "3");
-        assert_eq!(&*ss.get("b").unwrap().as_string(), "4");
-        assert_eq!(&*ss.get("c").unwrap().as_string(), "5");
+        assert_eq!(ss.get("a").unwrap().as_string(), "3");
+        assert_eq!(ss.get("b").unwrap().as_string(), "4");
+        assert_eq!(ss.get("c").unwrap().as_string(), "5");
 
         ss.pop();
-        assert_eq!(&*ss.get("a").unwrap().as_string(), "1");
-        assert_eq!(&*ss.get("b").unwrap().as_string(), "2");
+        assert_eq!(ss.get("a").unwrap().as_string(), "1");
+        assert_eq!(ss.get("b").unwrap().as_string(), "2");
         assert!(ss.get("c").is_none());
     }
 
@@ -281,17 +281,17 @@ mod tests {
 
         ss.push();
         ss.upvar(0, "a");
-        assert_eq!(&*ss.get("a").unwrap().as_string(), "1");
+        assert_eq!(ss.get("a").unwrap().as_string(), "1");
         assert!(ss.get("b").is_none());
 
         ss.set("a", Value::from("3"));
         ss.set("b", Value::from("4"));
-        assert_eq!(&*ss.get("a").unwrap().as_string(), "3");
-        assert_eq!(&*ss.get("b").unwrap().as_string(), "4");
+        assert_eq!(ss.get("a").unwrap().as_string(), "3");
+        assert_eq!(ss.get("b").unwrap().as_string(), "4");
 
         ss.pop();
-        assert_eq!(&*ss.get("a").unwrap().as_string(), "3");
-        assert_eq!(&*ss.get("b").unwrap().as_string(), "2");
+        assert_eq!(ss.get("a").unwrap().as_string(), "3");
+        assert_eq!(ss.get("b").unwrap().as_string(), "2");
     }
 
     #[test]
@@ -308,8 +308,8 @@ mod tests {
         ss.unset("b"); // Was not set in this scope
 
         ss.pop();
-        assert_eq!(&*ss.get("a").unwrap().as_string(), "1");
-        assert_eq!(&*ss.get("b").unwrap().as_string(), "2");
+        assert_eq!(ss.get("a").unwrap().as_string(), "1");
+        assert_eq!(ss.get("b").unwrap().as_string(), "2");
     }
 
     #[test]

--- a/molt/src/value.rs
+++ b/molt/src/value.rs
@@ -205,7 +205,7 @@ impl Display for Value {
 impl PartialEq for Value {
     // Two Values are equal if their string representations are equal.
     fn eq(&self, other: &Self) -> bool {
-        *self.as_string() == *other.as_string()
+        self.as_string() == other.as_string()
     }
 }
 
@@ -220,7 +220,7 @@ impl From<String> for Value {
     /// use molt::types::Value;
     /// let string = String::from("My New String");
     /// let value = Value::from(string);
-    /// assert_eq!(&*value.as_string(), "My New String");
+    /// assert_eq!(value.as_string(), "My New String");
     /// ```
     fn from(str: String) -> Self {
         Value::inner_from_string(str)
@@ -235,7 +235,7 @@ impl From<&str> for Value {
     /// ```
     /// use molt::types::Value;
     /// let value = Value::from("My String Slice");
-    /// assert_eq!(&*value.as_string(), "My String Slice");
+    /// assert_eq!(value.as_string(), "My String Slice");
     /// ```
     fn from(str: &str) -> Self {
         Value::inner_from_string(str.to_string())
@@ -252,7 +252,7 @@ impl From<&String> for Value {
     /// ```
     /// use molt::types::Value;
     /// let value = Value::from("My String Slice");
-    /// assert_eq!(&*value.as_string(), "My String Slice");
+    /// assert_eq!(value.as_string(), "My String Slice");
     /// ```
     fn from(str: &String) -> Self {
         Value::inner_from_string(str.to_string())
@@ -268,10 +268,10 @@ impl From<bool> for Value {
     /// ```
     /// use molt::types::Value;
     /// let value = Value::from(true);
-    /// assert_eq!(&*value.as_string(), "1");
+    /// assert_eq!(value.as_string(), "1");
     ///
     /// let value = Value::from(false);
-    /// assert_eq!(&*value.as_string(), "0");
+    /// assert_eq!(value.as_string(), "0");
     /// ```
     fn from(flag: bool) -> Self {
         Value::inner_from_data(DataRep::Bool(flag))
@@ -287,7 +287,7 @@ impl From<MoltInt> for Value {
     /// use molt::types::Value;
     ///
     /// let value = Value::from(123);
-    /// assert_eq!(&*value.as_string(), "123");
+    /// assert_eq!(value.as_string(), "123");
     /// ```
     fn from(int: MoltInt) -> Self {
         Value::inner_from_data(DataRep::Int(int))
@@ -311,7 +311,7 @@ impl From<MoltFloat> for Value {
     /// use molt::types::Value;
     ///
     /// let value = Value::from(12.34);
-    /// assert_eq!(&*value.as_string(), "12.34");
+    /// assert_eq!(value.as_string(), "12.34");
     /// ```
     fn from(flt: MoltFloat) -> Self {
         Value::inner_from_data(DataRep::Flt(flt))
@@ -328,7 +328,7 @@ impl From<MoltList> for Value {
     ///
     /// let list = vec![Value::from(1234), Value::from("abc")];
     /// let value = Value::from(list);
-    /// assert_eq!(&*value.as_string(), "1234 abc");
+    /// assert_eq!(value.as_string(), "1234 abc");
     /// ```
     fn from(list: MoltList) -> Self {
         Value::inner_from_data(DataRep::List(Rc::new(list)))
@@ -345,7 +345,7 @@ impl From<&[Value]> for Value {
     ///
     /// let values = [Value::from(1234), Value::from("abc")];
     /// let value = Value::from(&values[..]);
-    /// assert_eq!(&*value.as_string(), "1234 abc");
+    /// assert_eq!(value.as_string(), "1234 abc");
     /// ```
     fn from(list: &[Value]) -> Self {
         Value::inner_from_data(DataRep::List(Rc::new(list.to_vec())))
@@ -372,34 +372,9 @@ impl Value {
     /// ```
     /// use molt::types::Value;
     /// let value = Value::from(123);
-    /// assert_eq!(&*value.as_string(), "123");
+    /// assert_eq!(value.as_string(), "123");
     /// ```
-    pub fn as_string(&self) -> Rc<String> {
-        // FIRST, get the string rep, computing it from the data_rep if necessary.
-        let str = self.inner.string_rep.get_or_init(||
-            (self.inner.data_rep.borrow()).to_string()
-        );
-
-        // NEXT, return it in the expected form.
-        // TODO: Once we've got this module working, we'll change this method to
-        // return &String or &str
-        Rc::new(str.to_string())
-    }
-
-    /// Returns the value's string representation as a reference-counted
-    /// string.
-    ///
-    /// **Note**: This is the standard way of retrieving a `Value`'s
-    /// string rep, as unlike `to_string` it doesn't create a new `String`.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use molt::types::Value;
-    /// let value = Value::from(123);
-    /// assert_eq!(&*value.as_string(), "123");
-    /// ```
-    pub fn as_string2(&self) -> &str {
+    pub fn as_string(&self) -> &str {
         // FIRST, get the string rep, computing it from the data_rep if necessary.
         self.inner.string_rep.get_or_init(|| (self.inner.data_rep.borrow()).to_string())
     }
@@ -475,7 +450,7 @@ impl Value {
         }
 
         // NEXT, Try to parse the string_rep as a boolean
-        let str = self.as_string2();
+        let str = self.as_string();
         let flag = Value::get_bool(str)?;
         *(self.inner.data_rep.borrow_mut()) = DataRep::Bool(flag);
         Ok(flag)
@@ -548,7 +523,7 @@ impl Value {
         }
 
         // NEXT, Try to parse the string_rep as an integer
-        let str = self.as_string2();
+        let str = self.as_string();
         let int = Value::get_int(str)?;
         *self.inner.data_rep.borrow_mut() = DataRep::Int(int);
         Ok(int)
@@ -626,7 +601,7 @@ impl Value {
         }
 
         // NEXT, Try to parse the string_rep as a float
-        let str = self.as_string2();
+        let str = self.as_string();
         let flt = Value::get_float(str)?;
         *self.inner.data_rep.borrow_mut() = DataRep::Flt(flt);
         Ok(flt)
@@ -703,7 +678,7 @@ impl Value {
         }
 
         // NEXT, try to parse the string_rep as a list.
-        let str = self.as_string2();
+        let str = self.as_string();
         let list = Rc::new(get_list(str)?);
         *self.inner.data_rep.borrow_mut() = DataRep::List(list.clone());
 
@@ -754,7 +729,7 @@ impl Value {
     /// let value = Value::from_other(color);
     ///
     /// // Retrieve the value's string rep.
-    /// assert_eq!(&*value.as_string(), "#112233");
+    /// assert_eq!(value.as_string(), "#112233");
     /// ```
     ///
     /// See [`Value::as_other`](#method.as_other) and
@@ -821,7 +796,7 @@ impl Value {
 
         // NEXT, can we parse it as a T?  If so, save it back to
         // the data_rep, and return it.
-        let str = self.as_string2();
+        let str = self.as_string();
 
         if let Ok(tval) = str.parse::<T>() {
             let tval = Rc::new(tval);
@@ -884,7 +859,7 @@ impl Value {
 
         // NEXT, can we parse it as a T?  If so, save it back to
         // the data_rep, and return it.
-        let str = self.as_string2();
+        let str = self.as_string();
 
         if let Ok(tval) = str.parse::<T>() {
             let tval = Rc::new(tval);
@@ -996,22 +971,22 @@ mod tests {
     fn from_string() {
         // Using From<String>
         let val = Value::from("xyz".to_string());
-        assert_eq!(&*val.to_string(), "xyz");
+        assert_eq!(&val.to_string(), "xyz");
 
         // Using Into
         let val: Value = String::from("Fred").into();
-        assert_eq!(&*val.to_string(), "Fred");
+        assert_eq!(&val.to_string(), "Fred");
     }
 
     #[test]
     fn from_str_ref() {
         // Using From<&str>
         let val = Value::from("xyz");
-        assert_eq!(&*val.to_string(), "xyz");
+        assert_eq!(&val.to_string(), "xyz");
 
         // Using Into
         let val: Value = "Fred".into();
-        assert_eq!(&*val.to_string(), "Fred");
+        assert_eq!(&val.to_string(), "Fred");
     }
 
     #[test]
@@ -1025,10 +1000,10 @@ mod tests {
     #[test]
     fn as_string() {
         let val = Value::from("abc");
-        assert_eq!(*val.as_string(), "abc".to_string());
+        assert_eq!(val.as_string(), "abc");
 
         let val2 = val.clone();
-        assert_eq!(*val.as_string(), *val2.to_string());
+        assert_eq!(val.as_string(), val2.as_string());
     }
 
     #[test]
@@ -1045,10 +1020,10 @@ mod tests {
     fn from_bool() {
         // Using From<bool>
         let val = Value::from(true);
-        assert_eq!(&*val.to_string(), "1");
+        assert_eq!(&val.to_string(), "1");
 
         let val = Value::from(false);
-        assert_eq!(&*val.to_string(), "0");
+        assert_eq!(&val.to_string(), "0");
     }
 
     #[test]
@@ -1102,12 +1077,12 @@ mod tests {
     #[test]
     fn from_as_int() {
         let val = Value::from(5);
-        assert_eq!(&*val.as_string(), "5");
+        assert_eq!(val.as_string(), "5");
         assert_eq!(val.as_int(), Ok(5));
         assert_eq!(val.as_float(), Ok(5.0));
 
         let val = Value::from("7");
-        assert_eq!(&*val.as_string(), "7");
+        assert_eq!(val.as_string(), "7");
         assert_eq!(val.as_int(), Ok(7));
         assert_eq!(val.as_float(), Ok(7.0));
 
@@ -1115,7 +1090,7 @@ mod tests {
         // In Standard TCL, its string_rep would be "7.0".  Need to address
         // MoltFloat formatting/parsing.
         let val = Value::from(7.0);
-        assert_eq!(&*val.as_string(), "7");
+        assert_eq!(val.as_string(), "7");
         assert_eq!(val.as_int(), Ok(7));
         assert_eq!(val.as_float(), Ok(7.0));
 
@@ -1159,12 +1134,12 @@ mod tests {
     #[test]
     fn from_as_float() {
         let val = Value::from(12.5);
-        assert_eq!(&*val.as_string(), "12.5");
+        assert_eq!(val.as_string(), "12.5");
         assert_eq!(val.as_int(), molt_err!("expected integer but got \"12.5\""));
         assert_eq!(val.as_float(), Ok(12.5));
 
         let val = Value::from("7.8");
-        assert_eq!(&*val.as_string(), "7.8");
+        assert_eq!(val.as_string(), "7.8");
         assert_eq!(val.as_int(), molt_err!("expected integer but got \"7.8\""));
         assert_eq!(val.as_float(), Ok(7.8));
 
@@ -1206,7 +1181,7 @@ mod tests {
         // We *are* testing that Value will use the list.rs code to convert strings to lists
         // and back again.
         let listval = Value::from(vec![Value::from("abc"), Value::from("def")]);
-        assert_eq!(&*listval.as_string(), "abc def");
+        assert_eq!(listval.as_string(), "abc def");
 
         let listval = Value::from("qrs xyz");
         let result = listval.as_list();
@@ -1240,7 +1215,7 @@ mod tests {
         // and back again.
         let array = [Value::from("abc"), Value::from("def")];
         let listval = Value::from(&array[..]);
-        assert_eq!(&*listval.as_string(), "abc def");
+        assert_eq!(listval.as_string(), "abc def");
     }
 
     #[test]

--- a/notes/journal.md
+++ b/notes/journal.md
@@ -8,9 +8,6 @@ Things to remember to do soon:
 *   Review test_harness to use `Value` where appropriate.
 *   Review the context cache; make sure that "object commands" that use the context cache
     can easily drop the context if they are destroyed by `rename $cmd ""`.
-    *   If an "object command" is the only thing looking at its data, could we provide this
-        by allowing the `Command` struct to edit its own data?
-    *   It's getting a mutable interp; can it also have a mutable self?
 *   Document "Custom Shell Applications" in chapter 4 of the Molt Book.
 *   Before Tcl 2019:
     *   Publish Molt crates to crates.io.
@@ -33,6 +30,15 @@ Things to remember to do soon:
     `alloc` crate exists?
     *   Is this a reasonable goal?
     *   Would allow Molt to be used in embedded code.
+
+### 2019-08-03 (Saturday)
+*   Converted Value to use OnceCell.
+    *   Issue in as_float(): I'm getting a failure because of a double mutable borrow of the
+        data_rep.
+        *   `let val = Value::from(5);`, so that the data_rep is integer.
+        *   `let flt = val.as_float()?;`, so needs to convert the integer to a string, then
+            convert the string to a float.
+        *   But converting the integer to a string requires borrowing the integer.
 
 ### 2019-07-27 (Saturday)
 *   Looked into whether a Command struct could have mutable access to its fields, so that an


### PR DESCRIPTION
This pull request revises the internals of the `Value` type.  The `string_rep` is now contained within a `OnceCell`, to minimize the access costs on subsequent reads.  Only the `data_rep` is now contained in a `RefCell`.