### PR TITLE
Tokenizer

### DIFF
--- a/molt/src/char_star.rs
+++ b/molt/src/char_star.rs
@@ -90,58 +90,124 @@ mod tests {
     #[test]
     fn test_basics() {
         // Create the iterator
-        let mut ptr = CharStar::new("abcdefghijklmnopqrstuvwxyz");
-        assert_eq!(ptr.input(), "abcdefghijklmnopqrstuvwxyz");
-        assert_eq!(ptr.mark(), "abcdefghijklmnopqrstuvwxyz");
-        assert_eq!(ptr.head(), "abcdefghijklmnopqrstuvwxyz");
+        let mut ptr = CharStar::new("abc");
+
+        // Initial state
+        assert_eq!(ptr.input(), "abc");
+        assert_eq!(ptr.mark(), "abc");
+        assert_eq!(ptr.head(), "abc");
+        assert_eq!(ptr.peek(), Some('a'));
+        assert_eq!(ptr.token(), "");
+    }
+
+    #[test]
+    fn test_next() {
+        // Create the iterator
+        let mut ptr = CharStar::new("abc");
+
+        assert_eq!(ptr.next(), Some('a'));
+        assert_eq!(ptr.mark(), "abc");
+        assert_eq!(ptr.head(), "bc");
+
+        assert_eq!(ptr.next(), Some('b'));
+        assert_eq!(ptr.mark(), "abc");
+        assert_eq!(ptr.head(), "c");
+
+        assert_eq!(ptr.next(), Some('c'));
+        assert_eq!(ptr.mark(), "abc");
+        assert_eq!(ptr.head(), "");
+
+        assert_eq!(ptr.next(), None);
+    }
+
+    #[test]
+    fn test_mark_head() {
+        // Create the iterator
+        let mut ptr = CharStar::new("abcdef");
+
+        ptr.next();
+        ptr.next();
+        ptr.mark_head();
+
+        assert_eq!(ptr.mark(), "cdef");
+        assert_eq!(ptr.head(), "cdef");
+
+        ptr.next();
+        ptr.next();
+        assert_eq!(ptr.mark(), "cdef");
+        assert_eq!(ptr.head(), "ef");
+    }
+
+    #[test]
+    fn test_token() {
+        // Create the iterator
+        let mut ptr = CharStar::new("abcdef");
+
+        ptr.next();
+        ptr.next();
+        assert_eq!(ptr.token(), "ab");
+        assert_eq!(ptr.head(), "cdef");
+
+        ptr.mark_head();
+        ptr.next();
+        ptr.next();
+
+        assert_eq!(ptr.token(), "cd");
+        assert_eq!(ptr.head(), "ef");
+    }
+
+    #[test]
+    fn test_next_token() {
+        // Create the iterator
+        let mut ptr = CharStar::new("abcdef");
+
+        ptr.next();
+        ptr.next();
+        assert_eq!(ptr.next_token(), "ab");
+        assert_eq!(ptr.mark(), "cdef");
+
+        ptr.next();
+        ptr.next();
+        assert_eq!(ptr.next_token(), "cd");
+        assert_eq!(ptr.mark(), "ef");
+    }
+
+    #[test]
+    fn test_peek() {
+        let mut ptr = CharStar::new("abcdef");
+
+        assert_eq!(ptr.peek(), Some('a'));
+        assert_eq!(ptr.head(), "abcdef");
+
+        ptr.next();
+        ptr.next();
+
+        assert_eq!(ptr.peek(), Some('c'));
+        assert_eq!(ptr.head(), "cdef");
+    }
+
+    #[test]
+    fn test_backup() {
+        let mut ptr = CharStar::new("abcdef");
+
+        ptr.next();
+        ptr.next();
+        ptr.backup();
+
+        assert_eq!(ptr.mark(), "abcdef");
+        assert_eq!(ptr.head(), "abcdef");
         assert_eq!(ptr.peek(), Some('a'));
 
-        // Skip three characters
         ptr.next();
         ptr.next();
-        ptr.next();
-        assert_eq!(ptr.input(), "abcdefghijklmnopqrstuvwxyz");
-        assert_eq!(ptr.mark(), "abcdefghijklmnopqrstuvwxyz");
-        assert_eq!(ptr.head(), "defghijklmnopqrstuvwxyz");
-        assert_eq!(ptr.peek(), Some('d'));
-
-        // Mark the current spot
         ptr.mark_head();
-        assert_eq!(ptr.input(), "abcdefghijklmnopqrstuvwxyz");
-        assert_eq!(ptr.mark(), "defghijklmnopqrstuvwxyz");
-        assert_eq!(ptr.head(), "defghijklmnopqrstuvwxyz");
-        assert_eq!(ptr.peek(), Some('d'));
-
-        // Skip three more characters
         ptr.next();
         ptr.next();
-        ptr.next();
-        assert_eq!(ptr.input(), "abcdefghijklmnopqrstuvwxyz");
-        assert_eq!(ptr.mark(), "defghijklmnopqrstuvwxyz");
-        assert_eq!(ptr.head(), "ghijklmnopqrstuvwxyz");
-        assert_eq!(ptr.token(), "def");
-        assert_eq!(ptr.peek(), Some('g'));
-
-        // next_token
-        assert_eq!(ptr.next_token(), "def");
-        assert_eq!(ptr.input(), "abcdefghijklmnopqrstuvwxyz");
-        assert_eq!(ptr.mark(), "ghijklmnopqrstuvwxyz");
-        assert_eq!(ptr.head(), "ghijklmnopqrstuvwxyz");
-        assert_eq!(ptr.token(), "");
-        assert_eq!(ptr.peek(), Some('g'));
-
-        // backup
-        ptr.next();
-        ptr.next();
-        ptr.next();
-        assert_eq!(ptr.mark(), "ghijklmnopqrstuvwxyz");
-        assert_eq!(ptr.head(), "jklmnopqrstuvwxyz");
-        assert_eq!(ptr.token(), "ghi");
-        assert_eq!(ptr.peek(), Some('j'));
-
         ptr.backup();
-        assert_eq!(ptr.token(), "");
-        assert_eq!(ptr.head(), "ghijklmnopqrstuvwxyz");
-        assert_eq!(ptr.peek(), Some('g'));
+
+        assert_eq!(ptr.mark(), "cdef");
+        assert_eq!(ptr.head(), "cdef");
+        assert_eq!(ptr.peek(), Some('c'));
     }
+
 }

--- a/molt/src/char_star.rs
+++ b/molt/src/char_star.rs
@@ -1,3 +1,4 @@
+use std::iter::Peekable;
 use std::str::Chars;
 
 #[derive(Clone,Debug)]
@@ -12,7 +13,7 @@ pub struct CharStar<'a> {
     mark_index: usize,
 
     // The iterator used to extract characters from the input
-    chars: Chars<'a>,
+    chars: Peekable<Chars<'a>>,
 }
 
 impl<'a> CharStar<'a> {
@@ -22,7 +23,7 @@ impl<'a> CharStar<'a> {
             input,
             head_index: 0,
             mark_index: 0,
-            chars: input.chars(),
+            chars: input.chars().peekable(),
         }
     }
 
@@ -74,7 +75,7 @@ impl<'a> CharStar<'a> {
     // Resets the head to the mark.
     pub fn backup(&mut self) {
         self.head_index = self.mark_index;
-        self.chars = self.input[self.head_index..].chars();
+        self.chars = self.input[self.head_index..].chars().peekable();
     }
 }
 

--- a/molt/src/char_star.rs
+++ b/molt/src/char_star.rs
@@ -2,20 +2,27 @@ use std::str::Chars;
 
 #[derive(Clone,Debug)]
 pub struct CharStar<'a> {
+    // The string being parsed.
     input: &'a str,
-    chars: Chars<'a>,
+
+    // The starting index of the next character.
     head_index: usize,
+
+    // The starting index of the marked character
     mark_index: usize,
+
+    // The iterator used to extract characters from the input
+    chars: Chars<'a>,
 }
 
 impl<'a> CharStar<'a> {
-    // Create a new one for the given input.
+    // Create a new struct for the given input.
     pub fn new(input: &'a str) -> Self {
         Self {
             input,
-            chars: input.chars(),
             head_index: 0,
             mark_index: 0,
+            chars: input.chars(),
         }
     }
 

--- a/molt/src/char_star.rs
+++ b/molt/src/char_star.rs
@@ -1,0 +1,119 @@
+use std::str::Chars;
+
+#[derive(Clone,Debug)]
+pub struct CharStar<'a> {
+    input: &'a str,
+    mark: &'a str,
+    head: Chars<'a>,
+}
+
+impl<'a> CharStar<'a> {
+    // Create a new one for the given input.
+    pub fn new(input: &'a str) -> Self {
+        Self {
+            input,
+            mark: input,
+            head: input.chars(),
+        }
+    }
+
+    // Return the input.
+    pub fn input(&self) -> &str {
+        self.input
+    }
+
+    // Return from the mark to the end.
+    pub fn mark(&self) -> &str {
+        self.mark
+    }
+
+    // Return the remainder as a &str
+    pub fn head(&self) -> &str {
+        self.head.as_str()
+    }
+
+    // Return the next character. If we've peeked, return the peeked character.
+    // Otherwise just get the next one.
+    pub fn next(&mut self) -> Option<char> {
+        self.head.next()
+    }
+
+    // Start parsing a new token at the current head
+    pub fn mark_head(&mut self) {
+        self.mark = self.head.as_str();
+    }
+
+    // Get the token between the mark and the head.
+    pub fn token(&self) -> &str {
+        let head_len = self.head.as_str().len();
+        &self.mark[..self.mark.len() - head_len]
+    }
+
+    // Get the token between the mark and the head, and update the mark.
+    pub fn next_token(&mut self) -> &str {
+        let head_len = self.head.as_str().len();
+        let token = &self.mark[..self.mark.len() - head_len];
+        self.mark = self.head.as_str();
+        token
+    }
+
+    // Resets the head to the mark.
+    pub fn backup(&mut self) {
+        self.head = self.mark.chars();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basics() {
+        // Create the iterator
+        let mut ptr = CharStar::new("abcdefghijklmnopqrstuvwxyz");
+        assert_eq!(ptr.input(), "abcdefghijklmnopqrstuvwxyz");
+        assert_eq!(ptr.mark(), "abcdefghijklmnopqrstuvwxyz");
+        assert_eq!(ptr.head(), "abcdefghijklmnopqrstuvwxyz");
+
+        // Skip three characters
+        ptr.next();
+        ptr.next();
+        ptr.next();
+        assert_eq!(ptr.input(), "abcdefghijklmnopqrstuvwxyz");
+        assert_eq!(ptr.mark(), "abcdefghijklmnopqrstuvwxyz");
+        assert_eq!(ptr.head(), "defghijklmnopqrstuvwxyz");
+
+        // Mark the current spot
+        ptr.mark_head();
+        assert_eq!(ptr.input(), "abcdefghijklmnopqrstuvwxyz");
+        assert_eq!(ptr.mark(), "defghijklmnopqrstuvwxyz");
+        assert_eq!(ptr.head(), "defghijklmnopqrstuvwxyz");
+
+        // Skip three more characters
+        ptr.next();
+        ptr.next();
+        ptr.next();
+        assert_eq!(ptr.input(), "abcdefghijklmnopqrstuvwxyz");
+        assert_eq!(ptr.mark(), "defghijklmnopqrstuvwxyz");
+        assert_eq!(ptr.head(), "ghijklmnopqrstuvwxyz");
+        assert_eq!(ptr.token(), "def");
+
+        // next_token
+        assert_eq!(ptr.next_token(), "def");
+        assert_eq!(ptr.input(), "abcdefghijklmnopqrstuvwxyz");
+        assert_eq!(ptr.mark(), "ghijklmnopqrstuvwxyz");
+        assert_eq!(ptr.head(), "ghijklmnopqrstuvwxyz");
+        assert_eq!(ptr.token(), "");
+
+        // backup
+        ptr.next();
+        ptr.next();
+        ptr.next();
+        assert_eq!(ptr.token(), "ghi");
+        assert_eq!(ptr.head(), "jklmnopqrstuvwxyz");
+
+        ptr.backup();
+        assert_eq!(ptr.token(), "");
+        assert_eq!(ptr.head(), "ghijklmnopqrstuvwxyz");
+    }
+}

--- a/molt/src/char_star.rs
+++ b/molt/src/char_star.rs
@@ -65,15 +65,23 @@ impl<'a> CharStar<'a> {
     }
 
     // Get the token between the mark and the head.
-    pub fn token(&self) -> &str {
-        &self.input[self.mark_index..self.head_index]
+    pub fn token(&self) -> Option<&str> {
+        if self.mark_index != self.head_index {
+            Some(&self.input[self.mark_index..self.head_index])
+        } else {
+            None
+        }
     }
 
     // Get the token between the mark and the head, and update the mark.
-    pub fn next_token(&mut self) -> &str {
-        let token = &self.input[self.mark_index..self.head_index];
-        self.mark_index = self.head_index;
-        token
+    pub fn next_token(&mut self) -> Option<&str> {
+        if self.mark_index != self.head_index {
+            let token = &self.input[self.mark_index..self.head_index];
+            self.mark_index = self.head_index;
+            Some(token)
+        } else {
+            None
+        }
     }
 
     // Resets the head to the mark.
@@ -97,7 +105,7 @@ mod tests {
         assert_eq!(ptr.mark(), "abc");
         assert_eq!(ptr.head(), "abc");
         assert_eq!(ptr.peek(), Some('a'));
-        assert_eq!(ptr.token(), "");
+        assert_eq!(ptr.token(), None);
     }
 
     #[test]
@@ -145,14 +153,14 @@ mod tests {
 
         ptr.next();
         ptr.next();
-        assert_eq!(ptr.token(), "ab");
+        assert_eq!(ptr.token(), Some("ab"));
         assert_eq!(ptr.head(), "cdef");
 
         ptr.mark_head();
         ptr.next();
         ptr.next();
 
-        assert_eq!(ptr.token(), "cd");
+        assert_eq!(ptr.token(), Some("cd"));
         assert_eq!(ptr.head(), "ef");
     }
 
@@ -160,15 +168,16 @@ mod tests {
     fn test_next_token() {
         // Create the iterator
         let mut ptr = CharStar::new("abcdef");
+        assert_eq!(ptr.next_token(), None);
 
         ptr.next();
         ptr.next();
-        assert_eq!(ptr.next_token(), "ab");
+        assert_eq!(ptr.next_token(), Some("ab"));
         assert_eq!(ptr.mark(), "cdef");
 
         ptr.next();
         ptr.next();
-        assert_eq!(ptr.next_token(), "cd");
+        assert_eq!(ptr.next_token(), Some("cd"));
         assert_eq!(ptr.mark(), "ef");
     }
 
@@ -209,5 +218,4 @@ mod tests {
         assert_eq!(ptr.head(), "cdef");
         assert_eq!(ptr.peek(), Some('c'));
     }
-
 }

--- a/molt/src/char_star.rs
+++ b/molt/src/char_star.rs
@@ -4,7 +4,7 @@ use std::str::Chars;
 pub struct CharStar<'a> {
     input: &'a str,
     mark: &'a str,
-    head: Chars<'a>,
+    chars: Chars<'a>,
 }
 
 impl<'a> CharStar<'a> {
@@ -13,7 +13,7 @@ impl<'a> CharStar<'a> {
         Self {
             input,
             mark: input,
-            head: input.chars(),
+            chars: input.chars(),
         }
     }
 
@@ -29,37 +29,37 @@ impl<'a> CharStar<'a> {
 
     // Return the remainder as a &str
     pub fn head(&self) -> &str {
-        self.head.as_str()
+        self.chars.as_str()
     }
 
     // Return the next character. If we've peeked, return the peeked character.
     // Otherwise just get the next one.
     pub fn next(&mut self) -> Option<char> {
-        self.head.next()
+        self.chars.next()
     }
 
     // Start parsing a new token at the current head
     pub fn mark_head(&mut self) {
-        self.mark = self.head.as_str();
+        self.mark = self.chars.as_str();
     }
 
     // Get the token between the mark and the head.
     pub fn token(&self) -> &str {
-        let head_len = self.head.as_str().len();
+        let head_len = self.chars.as_str().len();
         &self.mark[..self.mark.len() - head_len]
     }
 
     // Get the token between the mark and the head, and update the mark.
     pub fn next_token(&mut self) -> &str {
-        let head_len = self.head.as_str().len();
+        let head_len = self.chars.as_str().len();
         let token = &self.mark[..self.mark.len() - head_len];
-        self.mark = self.head.as_str();
+        self.mark = self.chars.as_str();
         token
     }
 
     // Resets the head to the mark.
     pub fn backup(&mut self) {
-        self.head = self.mark.chars();
+        self.chars = self.mark.chars();
     }
 }
 

--- a/molt/src/char_star.rs
+++ b/molt/src/char_star.rs
@@ -55,6 +55,10 @@ impl<'a> CharStar<'a> {
         ch
     }
 
+    pub fn peek(&mut self) -> Option<char> {
+        self.chars.peek().copied()
+    }
+
     // Start parsing a new token at the current head
     pub fn mark_head(&mut self) {
         self.mark_index = self.head_index;
@@ -90,6 +94,7 @@ mod tests {
         assert_eq!(ptr.input(), "abcdefghijklmnopqrstuvwxyz");
         assert_eq!(ptr.mark(), "abcdefghijklmnopqrstuvwxyz");
         assert_eq!(ptr.head(), "abcdefghijklmnopqrstuvwxyz");
+        assert_eq!(ptr.peek(), Some('a'));
 
         // Skip three characters
         ptr.next();
@@ -98,12 +103,14 @@ mod tests {
         assert_eq!(ptr.input(), "abcdefghijklmnopqrstuvwxyz");
         assert_eq!(ptr.mark(), "abcdefghijklmnopqrstuvwxyz");
         assert_eq!(ptr.head(), "defghijklmnopqrstuvwxyz");
+        assert_eq!(ptr.peek(), Some('d'));
 
         // Mark the current spot
         ptr.mark_head();
         assert_eq!(ptr.input(), "abcdefghijklmnopqrstuvwxyz");
         assert_eq!(ptr.mark(), "defghijklmnopqrstuvwxyz");
         assert_eq!(ptr.head(), "defghijklmnopqrstuvwxyz");
+        assert_eq!(ptr.peek(), Some('d'));
 
         // Skip three more characters
         ptr.next();
@@ -113,6 +120,7 @@ mod tests {
         assert_eq!(ptr.mark(), "defghijklmnopqrstuvwxyz");
         assert_eq!(ptr.head(), "ghijklmnopqrstuvwxyz");
         assert_eq!(ptr.token(), "def");
+        assert_eq!(ptr.peek(), Some('g'));
 
         // next_token
         assert_eq!(ptr.next_token(), "def");
@@ -120,6 +128,7 @@ mod tests {
         assert_eq!(ptr.mark(), "ghijklmnopqrstuvwxyz");
         assert_eq!(ptr.head(), "ghijklmnopqrstuvwxyz");
         assert_eq!(ptr.token(), "");
+        assert_eq!(ptr.peek(), Some('g'));
 
         // backup
         ptr.next();
@@ -128,9 +137,11 @@ mod tests {
         assert_eq!(ptr.mark(), "ghijklmnopqrstuvwxyz");
         assert_eq!(ptr.head(), "jklmnopqrstuvwxyz");
         assert_eq!(ptr.token(), "ghi");
+        assert_eq!(ptr.peek(), Some('j'));
 
         ptr.backup();
         assert_eq!(ptr.token(), "");
         assert_eq!(ptr.head(), "ghijklmnopqrstuvwxyz");
+        assert_eq!(ptr.peek(), Some('g'));
     }
 }

--- a/molt/src/eval_ptr.rs
+++ b/molt/src/eval_ptr.rs
@@ -115,19 +115,6 @@ impl<'a> EvalPtr<'a> {
         }
     }
 
-    /// Is the current character is a valid list whitespace character?
-    pub fn next_is_list_white(&mut self) -> bool {
-        match self.chars.peek() {
-            Some(' ') => true,
-            Some('\n') => true,
-            Some('\r') => true,
-            Some('\t') => true,
-            Some('\x0B') => true, // Vertical Tab
-            Some('\x0C') => true, // Form Feed
-            _ => false,
-        }
-    }
-
     /// Is the current character a valid variable name character?
     pub fn next_is_varname_char(&mut self) -> bool {
         match self.chars.peek() {
@@ -168,15 +155,6 @@ impl<'a> EvalPtr<'a> {
     /// current command, or on a non-white-space character.
     pub fn skip_line_white(&mut self) {
         while !self.at_end() && self.next_is_line_white() {
-            self.chars.next();
-        }
-    }
-
-    /// Skips past any whitespace in a list.
-    /// When this returns we are at the end of the input or at the beginning of
-    /// the next list item.
-    pub fn skip_list_white(&mut self) {
-        while !self.at_end() && self.next_is_list_white() {
             self.chars.next();
         }
     }

--- a/molt/src/interp.rs
+++ b/molt/src/interp.rs
@@ -153,7 +153,7 @@ pub struct Interp {
     last_context_id: u64,
 
     // Context Map
-    context_map: HashMap<ContextID, Box<Any>>,
+    context_map: HashMap<ContextID, Box<dyn Any>>,
 
     // Defines the recursion limit for Interp::eval().
     recursion_limit: usize,

--- a/molt/src/interp.rs
+++ b/molt/src/interp.rs
@@ -1263,7 +1263,6 @@ fn subst_backslash(ctx: &mut EvalPtr, word: &mut String) {
                 word.push(val as char);
             }
             // \xhh -- 2 hex digits
-            // \Uhhhhhhhh -- 1 to 8 hex digits
             'x' => {
                 if !ctx.next_is_hex_digit() {
                     word.push(c);

--- a/molt/src/interp.rs
+++ b/molt/src/interp.rs
@@ -1512,7 +1512,7 @@ mod tests {
         assert_eq!("1\t2", interp.subst_backslashes("1\\t2"));
         assert_eq!("1\x0b2", interp.subst_backslashes("1\\v2"));
         assert_eq!("1\x072", interp.subst_backslashes("1\\0072"));
-        assert_eq!("XpY", interp.subst_backslashes("X\x70Y"));
+        assert_eq!("XpY", interp.subst_backslashes("X\\x70Y"));
         assert_eq!("X\x07Y", interp.subst_backslashes("X\\u7Y"));
         assert_eq!("XwY", interp.subst_backslashes("X\\u77Y"));
         assert_eq!("XwY", interp.subst_backslashes("X\\u077Y"));

--- a/molt/src/interp.rs
+++ b/molt/src/interp.rs
@@ -1263,6 +1263,7 @@ fn subst_backslash(ctx: &mut EvalPtr, word: &mut String) {
                 word.push(val as char);
             }
             // \xhh -- 2 hex digits
+            // TODO: This is wrong, as it requires 2 hex digits; Tcl allows 1 or 2.
             'x' => {
                 if !ctx.next_is_hex_digit() {
                     word.push(c);

--- a/molt/src/lib.rs
+++ b/molt/src/lib.rs
@@ -10,6 +10,8 @@ pub use crate::types::*;
 
 #[allow(dead_code)] // Temporary
 mod char_ptr;
+#[allow(dead_code)] // Temporary
+mod char_star;
 mod commands;
 mod eval_ptr;
 #[allow(dead_code)] // Temporary

--- a/molt/src/lib.rs
+++ b/molt/src/lib.rs
@@ -11,7 +11,7 @@ pub use crate::types::*;
 #[allow(dead_code)] // Temporary
 mod char_ptr;
 #[allow(dead_code)] // Temporary
-mod char_star;
+mod tokenizer;
 mod commands;
 mod eval_ptr;
 #[allow(dead_code)] // Temporary

--- a/molt/src/list.rs
+++ b/molt/src/list.rs
@@ -72,7 +72,7 @@ fn parse_braced_item(ctx: &mut Tokenizer) -> MoltResult {
     let mut count = 1;
 
     // NEXT, mark the start of the token, and skip characters until we find the end.
-    ctx.mark_head();
+    let mark = ctx.head_index();
     while let Some(c) = ctx.peek() {
         if c == '\\' {
             // Backslash handling. Retain backslashes as is.
@@ -92,7 +92,7 @@ fn parse_braced_item(ctx: &mut Tokenizer) -> MoltResult {
                 // We've found and consumed the closing brace.  We should either
                 // see more more whitespace, or we should be at the end of the list
                 // Otherwise, there are incorrect characters following the close-brace.
-                let result = Ok(Value::from(ctx.token().unwrap()));
+                let result = Ok(Value::from(ctx.token(mark).unwrap()));
                 ctx.skip(); // Skip the closing brace
 
                 if ctx.at_end() || ctx.has(|ch| is_list_white(*ch)) {

--- a/molt/src/list.rs
+++ b/molt/src/list.rs
@@ -306,6 +306,25 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_parse_braced_item() {
+        assert_eq!(pbi("{abc}"), "abc|".to_string());
+        assert_eq!(pbi("{abc}  "), "abc|  ".to_string());
+        assert_eq!(pbi("{a{b}c}"), "a{b}c|".to_string());
+        assert_eq!(pbi("{a{b}{c}}"), "a{b}{c}|".to_string());
+        assert_eq!(pbi("{a{b}{c}d}"), "a{b}{c}d|".to_string());
+        assert_eq!(pbi("{a{b}{c}d} efg"), "a{b}{c}d| efg".to_string());
+    }
+
+    fn pbi(input: &str) -> String {
+        let mut ctx = Tokenizer::new(input);
+        if let Ok(val) = parse_braced_item(&mut ctx) {
+            format!("{}|{}", val.as_str(), ctx.head())
+        } else {
+            String::from("Err")
+        }
+    }
+
     // Most list parsing is tested in the Molt test suite.
 
     #[test]

--- a/molt/src/list.rs
+++ b/molt/src/list.rs
@@ -17,6 +17,19 @@ pub(crate) fn get_list(str: &str) -> Result<MoltList, ResultCode> {
     parse_list(&mut ctx)
 }
 
+// Is the character is valid list whitespace character?
+// fn is_list_white(ch: Option<char>) -> bool {
+//     match ch {
+//         Some(' ') => true,
+//         Some('\n') => true,
+//         Some('\r') => true,
+//         Some('\t') => true,
+//         Some('\x0B') => true, // Vertical Tab
+//         Some('\x0C') => true, // Form Feed
+//         _ => false,
+//     }
+// }
+
 fn parse_list(ctx: &mut EvalPtr) -> Result<MoltList, ResultCode> {
     // FIRST, skip any list whitespace.
     ctx.skip_list_white();

--- a/molt/src/list.rs
+++ b/molt/src/list.rs
@@ -72,7 +72,7 @@ fn parse_braced_item(ctx: &mut Tokenizer) -> MoltResult {
     let mut count = 1;
 
     // NEXT, mark the start of the token, and skip characters until we find the end.
-    let mark = ctx.head_index();
+    let mark = ctx.mark();
     while let Some(c) = ctx.peek() {
         if c == '\\' {
             // Backslash handling. Retain backslashes as is.
@@ -319,7 +319,7 @@ mod tests {
     fn pbi(input: &str) -> String {
         let mut ctx = Tokenizer::new(input);
         if let Ok(val) = parse_braced_item(&mut ctx) {
-            format!("{}|{}", val.as_str(), ctx.head())
+            format!("{}|{}", val.as_str(), ctx.as_str())
         } else {
             String::from("Err")
         }
@@ -335,7 +335,7 @@ mod tests {
     fn pqi(input: &str) -> String {
         let mut ctx = Tokenizer::new(input);
         if let Ok(val) = parse_quoted_item(&mut ctx) {
-            format!("{}|{}", val.as_str(), ctx.head())
+            format!("{}|{}", val.as_str(), ctx.as_str())
         } else {
             String::from("Err")
         }

--- a/molt/src/list.rs
+++ b/molt/src/list.rs
@@ -115,34 +115,6 @@ fn parse_quoted_item(ctx: &mut Tokenizer) -> MoltResult {
     // FIRST, consume the the opening quote.
     ctx.next();
 
-    // NEXT, add characters to the item until we reach the close quote
-    let mut item = String::new();
-
-    while !ctx.at_end() {
-        // Note: the while condition ensures that there's a character.
-        if ctx.is('\\') {
-            // Backslash; push this character and the next.
-            item.push(ctx.next().unwrap());
-            if !ctx.at_end() {
-                item.push(ctx.next().unwrap());
-            }
-        } else if !ctx.is('"') {
-            item.push(ctx.next().unwrap());
-        } else {
-            ctx.skip(); // skipping '"'
-            return Ok(Value::from(subst_backslashes(&item)));
-        }
-    }
-
-    molt_err!("unmatched open quote in list")
-}
-
-/// Parse a quoted item.  Does backslash substitution.
-fn parse_quoted_item2(ctx: &mut Tokenizer) -> MoltResult {
-    // FIRST, consume the the opening quote.
-    ctx.next();
-
-    // NEXT, add characters to the item until we reach the close quote
     let mut item = String::new();
 
     while !ctx.at_end() {

--- a/molt/src/tokenizer.rs
+++ b/molt/src/tokenizer.rs
@@ -2,7 +2,7 @@ use std::iter::Peekable;
 use std::str::Chars;
 
 #[derive(Clone,Debug)]
-pub struct CharStar<'a> {
+pub struct Tokenizer<'a> {
     // The string being parsed.
     input: &'a str,
 
@@ -16,7 +16,7 @@ pub struct CharStar<'a> {
     chars: Peekable<Chars<'a>>,
 }
 
-impl<'a> CharStar<'a> {
+impl<'a> Tokenizer<'a> {
     // Create a new struct for the given input.
     pub fn new(input: &'a str) -> Self {
         Self {
@@ -98,7 +98,7 @@ mod tests {
     #[test]
     fn test_basics() {
         // Create the iterator
-        let mut ptr = CharStar::new("abc");
+        let mut ptr = Tokenizer::new("abc");
 
         // Initial state
         assert_eq!(ptr.input(), "abc");
@@ -111,7 +111,7 @@ mod tests {
     #[test]
     fn test_next() {
         // Create the iterator
-        let mut ptr = CharStar::new("abc");
+        let mut ptr = Tokenizer::new("abc");
 
         assert_eq!(ptr.next(), Some('a'));
         assert_eq!(ptr.mark(), "abc");
@@ -131,7 +131,7 @@ mod tests {
     #[test]
     fn test_mark_head() {
         // Create the iterator
-        let mut ptr = CharStar::new("abcdef");
+        let mut ptr = Tokenizer::new("abcdef");
 
         ptr.next();
         ptr.next();
@@ -149,7 +149,7 @@ mod tests {
     #[test]
     fn test_token() {
         // Create the iterator
-        let mut ptr = CharStar::new("abcdef");
+        let mut ptr = Tokenizer::new("abcdef");
 
         ptr.next();
         ptr.next();
@@ -167,7 +167,7 @@ mod tests {
     #[test]
     fn test_next_token() {
         // Create the iterator
-        let mut ptr = CharStar::new("abcdef");
+        let mut ptr = Tokenizer::new("abcdef");
         assert_eq!(ptr.next_token(), None);
 
         ptr.next();
@@ -183,7 +183,7 @@ mod tests {
 
     #[test]
     fn test_peek() {
-        let mut ptr = CharStar::new("abcdef");
+        let mut ptr = Tokenizer::new("abcdef");
 
         assert_eq!(ptr.peek(), Some('a'));
         assert_eq!(ptr.head(), "abcdef");
@@ -197,7 +197,7 @@ mod tests {
 
     #[test]
     fn test_backup() {
-        let mut ptr = CharStar::new("abcdef");
+        let mut ptr = Tokenizer::new("abcdef");
 
         ptr.next();
         ptr.next();

--- a/molt/src/tokenizer.rs
+++ b/molt/src/tokenizer.rs
@@ -136,14 +136,14 @@ impl<'a> Tokenizer<'a> {
     /// Skip over the next character, updating the head.  This is equivalent to
     /// `next`, but communicates better.
     pub fn skip(&mut self) {
-        self.chars.next();
+        self.next();
     }
 
     /// Skips the given number of characters, updating the head.
     /// It is not an error if the iterator doesn't contain that many.
     pub fn skip_over(&mut self, num_chars: usize) {
         for _ in 0..num_chars {
-            self.chars.next();
+            self.next();
         }
     }
 
@@ -154,7 +154,7 @@ impl<'a> Tokenizer<'a> {
     {
         while let Some(ch) = self.chars.peek() {
             if predicate(ch) {
-                self.chars.next();
+                self.next();
             } else {
                 break;
             }
@@ -313,29 +313,51 @@ mod tests {
     fn test_skip() {
         let mut ptr = Tokenizer::new("abc");
 
-        assert_eq!(Some('a'), ptr.peek());
+        assert_eq!(ptr.peek(), Some('a'));
+        assert_eq!(ptr.head(), "abc");
+
         ptr.skip();
-        assert_eq!(Some('b'), ptr.peek());
+        assert_eq!(ptr.peek(), Some('b'));
+        assert_eq!(ptr.head(), "bc");
+
         ptr.skip();
-        assert_eq!(Some('c'), ptr.peek());
+        assert_eq!(ptr.peek(), Some('c'));
+        assert_eq!(ptr.head(), "c");
+
         ptr.skip();
-        assert_eq!(None, ptr.peek());
+        assert_eq!(ptr.peek(), None);
+        assert_eq!(ptr.head(), "");
     }
 
     #[test]
     fn test_skip_over() {
         let mut ptr = Tokenizer::new("abc");
         ptr.skip_over(2);
-        assert_eq!(Some('c'), ptr.peek());
+        assert_eq!(ptr.peek(), Some('c'));
+        assert_eq!(ptr.head(), "c");
 
         let mut ptr = Tokenizer::new("abc");
         ptr.skip_over(3);
-        assert_eq!(None, ptr.peek());
+        assert_eq!(ptr.peek(), None);
+        assert_eq!(ptr.head(), "");
 
         let mut ptr = Tokenizer::new("abc");
         ptr.skip_over(6);
-        assert_eq!(None, ptr.peek());
+        assert_eq!(ptr.peek(), None);
+        assert_eq!(ptr.head(), "");
     }
 
+    #[test]
+    fn test_skip_while() {
+        let mut ptr = Tokenizer::new("aaabc");
+        ptr.skip_while(|ch| *ch == 'a');
+        assert_eq!(ptr.peek(), Some('b'));
+        assert_eq!(ptr.head(), "bc");
+
+        let mut ptr = Tokenizer::new("aaa");
+        ptr.skip_while(|ch| *ch == 'a');
+        assert_eq!(ptr.peek(), None);
+        assert_eq!(ptr.head(), "");
+    }
 
 }

--- a/notes/journal.md
+++ b/notes/journal.md
@@ -32,6 +32,21 @@ Things to remember to do soon:
     *   Is this a reasonable goal?
     *   Would allow Molt to be used in embedded code.
 
+### 2019-08-11 (Sunday)
+*   Parsing with string slices.
+    *   On reflection, CharStar (or whatever I finally call it) really needs to support
+        peeking efficiently, because I use that constantly.  There's no good way to
+        implement `skip_while`, etc., without it.
+    *   The best solution I've come up with so far (if it works) is to maintain the
+        "head" index myself, by accumulating the lengths of the `next` characters as I
+        extract them.
+        *   And then, `head()` is `&input[head_index..]`.  If that works.
+    *   And then peeking is neither here nor there; the `head_index` doesn't change until
+        `next()` is called.
+    *   Note: I've asked on user.rust-lang-org whether there's a way to get `as_str` from a
+        `Peekable<Chars>`.  I'm expecting not.
+
+
 ### 2019-08-10 (Saturday)
 *   Returning data_rep as `Ref<T>`.
     *   With help from jethrogb@users.rust-lang.org.

--- a/notes/journal.md
+++ b/notes/journal.md
@@ -56,6 +56,14 @@ Things to remember to do soon:
     *   https://users.rust-lang.org/t/takewhile-iterator-over-chars-to-string-slice/11014
     *   Tried this in repo `slice-parse`.  Works like a charm.
     *   Wrote a quick blog post: https://wduquette.github.io/parsing-strings-into-slices/.
+*   Working out my parsing infrastructure:
+    *   See char_star.rs, list2.rs, which contain my experiments.
+    *   Can't use `Peekable<Chars>`, as it doesn't support `as_str`.  Damn, that's annoying.
+    *   Implementing peeking is tricky.
+        *   Tried something and backed it out because it was getting complicated and I couldn't
+            be sure I was getting it right.
+    *   Can we do without it by marking before we peek, with `backup` as a last resort?
+        *   Maybe?
 
 ### 2019-08-03 (Saturday)
 *   Converting Value to use OnceCell.

--- a/notes/journal.md
+++ b/notes/journal.md
@@ -45,6 +45,10 @@ Things to remember to do soon:
         `next()` is called.
     *   Note: I've asked on user.rust-lang-org whether there's a way to get `as_str` from a
         `Peekable<Chars>`.  I'm expecting not.
+    *   Revised CharStar (I need a better name!) to track the head and mark using integer
+        indices.  The code no longer uses `as_str` at all.  The `chars` iterator is
+        recreated only on `backup`.  I don't think there's any reason not to use a
+        `Peekable<Chars>` at this point.
 
 
 ### 2019-08-10 (Saturday)

--- a/notes/journal.md
+++ b/notes/journal.md
@@ -34,6 +34,25 @@ Things to remember to do soon:
     *   Is this a reasonable goal?
     *   Would allow Molt to be used in embedded code.
 
+### 2019-08-18 (Sunday)
+*   Backslash Substitution
+    *   It appears that the backslash substitution code pushes multiple characters in
+        some cases.  Why?
+        *   The `\x` case
+            *   Zero hex digits
+                *   Pushes `x`
+            *   One hex digit
+                *   Pushes `x` and the single digit.
+            *   Two hex digits
+                *   If the hex number is a valid character, pushes it
+                *   Otherwise, pushes `x` followed by the two hex digits.
+        *   The `\u` and `\U` cases
+            *   Similar: if the escape can't be translated into a valid character,
+                outputs `u` or `U` followed by whatever hex characters it had.
+    *   Took another look at Tcl 8.
+        *   `\x` should accept one or two digits.  It returns `x` if there are
+            no following hex digits.  Need to fix that.
+
 ### 2019-08-17 (Saturday)
 *   Parsing with string slices
     *   Revised list.rs to use Tokenizer rather than EvalPtr, but naively

--- a/notes/journal.md
+++ b/notes/journal.md
@@ -52,6 +52,17 @@ Things to remember to do soon:
     *   Took another look at Tcl 8.
         *   `\x` should accept one or two digits.  It returns `x` if there are
             no following hex digits.  Need to fix that.
+    *   Essential points:
+        *   Either the token is a single character, or a slice.
+        *   Either way, it's a distinct token in a quoted or bare item.  The previous
+            token ends just before the `\`, and the next token begins just after the
+            last character read.
+        *   Oh, but wait.  A backslash substitution always returns a single character:
+            either the translated character, or the character immediately following the
+            backslash.  For hex substitutions that fail, returning the hex digits as
+            part of the token *might* be an optimization; but it's certainly OK to just
+            reset parsing to the first hex digit, especially since it's rare.
+    *   Added Tokenizer::backslash_subst, which returns a single character.
 
 ### 2019-08-17 (Saturday)
 *   Parsing with string slices

--- a/notes/journal.md
+++ b/notes/journal.md
@@ -53,7 +53,38 @@ Things to remember to do soon:
         `Peekable<Chars>` at this point.
     *   CharStar now uses a `Peekable<Char>` and provides `peek()`.  Also, the token
         methods return `Option<&str>` so that they can return `None` when there's no token
-        instead of `""`.
+    *   Renamed CharStar to Tokenizer.
+*   The next question is what features do I want to add to Tokenizer?
+    *   How much should it know about Molt-specific characters?  I.e., what predicates
+        should it support?
+    *   Or, should I define a set of standard predicates, and just provide the "has" method
+        from char_ptr?
+        *   I'm thinking this.
+    *   What features of EvalPtr does list.rs use?
+        *   skip_list_white
+            *   Use char_ptr's `skip_while` with a predicate.
+        *   next_is_list_white
+            *   Use char_ptr's `has` with a predicate.
+        *   at_end_of_command
+            *   I'm not at all sure that list.rs should be using this; I think it will
+                exclude ";" from the list.
+            *   Yeah, this is a bug:
+```tcl
+set a {a b ;c d}
+
+# Prints only a and b
+foreach item $a {puts $item}
+```
+            *   Wrote Issue #43.
+        *   next_is
+            *   Use char_ptr's `is`
+        *   at_end
+            *   Same as char_ptr's `is_none`, but `at_end` is better.
+        *   skip_char
+            *   Like char_ptr's `skip`, but with assertion that we're skipping what
+                we expected to skip.
+            *   Can add it if it seems necessary.
+
 
 ### 2019-08-10 (Saturday)
 *   Returning data_rep as `Ref<T>`.

--- a/notes/journal.md
+++ b/notes/journal.md
@@ -34,6 +34,28 @@ Things to remember to do soon:
     *   Is this a reasonable goal?
     *   Would allow Molt to be used in embedded code.
 
+### 2019-08-17 (Saturday)
+*   Parsing with string slices
+    *   Revised list.rs to use Tokenizer rather than EvalPtr, but naively
+        *   I.e., still builds up string output character by character.
+    *   Parsing braced items.
+        *   list.rs handles braced items by accumulating a slice.
+        *   Fixed the `Tokenizer::skip*` methods, which didn't update the head.
+    *   Parsing quoted items.
+        *   Current code accumulates the output string character by character, skipping
+            backslash escapes, then does backslash substitution...which again accumulates
+            the output string character by character.  This is *way* slow.
+        *   The quoted string consists of:
+            *   An open quote
+            *   Zero or more tokens
+            *   A close quote
+        *   The individual tokens are:
+            *   Normal strings
+            *   Substituted backslash escapes
+        *   So we are building up a string token by token rather than character by character.
+            *   And we only want to make one pass.
+
+
 ### 2019-08-11 (Sunday)
 *   Parsing with string slices.
     *   On reflection, CharStar (or whatever I finally call it) really needs to support

--- a/notes/journal.md
+++ b/notes/journal.md
@@ -4,9 +4,10 @@ Things to remember to do soon:
 
 *   Revise Value per Yandros' style comments here:
     https://users.rust-lang.org/t/lazy-initialization-vs-interior-mutability/30742/7
-*   Revise the parsing code to use iterator subtraction to extract slices, rather than
+*   Revise the parsing code to use Tokenizer to extract slices, rather than
     building up small strings a character at a time.
-    *   https://users.rust-lang.org/t/takewhile-iterator-over-chars-to-string-slice/11014
+    *   interp::
+    *   expr::
 *   Flesh out the interp.rs test suite and rustdocs.
 *   Review test_harness to use `Value` where appropriate.
 *   Review the context cache; make sure that "object commands" that use the context cache
@@ -33,6 +34,10 @@ Things to remember to do soon:
     `alloc` crate exists?
     *   Is this a reasonable goal?
     *   Would allow Molt to be used in embedded code.
+
+### 2019-08-19 (Monday)
+*   Revised list::parse_quoted_item and list::parse_bare_item to use slices.
+    *   Now I need to devise a benchmark for this.
 
 ### 2019-08-18 (Sunday)
 *   Backslash Substitution

--- a/notes/journal.md
+++ b/notes/journal.md
@@ -64,6 +64,11 @@ Things to remember to do soon:
             be sure I was getting it right.
     *   Can we do without it by marking before we peek, with `backup` as a last resort?
         *   Maybe?
+    *   Some alternatives to what I'm trying:
+        *   Parsing functions:
+            *   Like nom: given a `&str`, return two `&str`, the token and the next character.
+            *   Seems like it would involve creating a new Chars iterator in each function,
+                though.
 
 ### 2019-08-03 (Saturday)
 *   Converting Value to use OnceCell.

--- a/notes/journal.md
+++ b/notes/journal.md
@@ -63,6 +63,15 @@ Things to remember to do soon:
             part of the token *might* be an optimization; but it's certainly OK to just
             reset parsing to the first hex digit, especially since it's rare.
     *   Added Tokenizer::backslash_subst, which returns a single character.
+*   Thoughts on Tokenizer:
+    *   There's no need to be able to save an internal "mark".  Instead:
+        *   `index()` returns the head_index.
+        *   `token(usize)` returns the token from the given index to the head.
+        *   `tail(usize)` return the entire string from the given index to the head.
+        *   `reset(usize)` resets the iterator to the given index.
+        *   The `head_index` becomes just the `index`.
+    *   The client can then save as many "marks" as it needs, with no fear of
+        confusion.
 
 ### 2019-08-17 (Saturday)
 *   Parsing with string slices

--- a/notes/journal.md
+++ b/notes/journal.md
@@ -54,6 +54,9 @@ Things to remember to do soon:
             *   Substituted backslash escapes
         *   So we are building up a string token by token rather than character by character.
             *   And we only want to make one pass.
+    *   The first step is to make a copy of `interp::subst_backslash` that consumes
+        a backslash sequence from the tokenizer and returns the resulting character.
+        *   The subst_backslash code sometimes returns more than one character.  How come?
 
 
 ### 2019-08-11 (Sunday)

--- a/notes/journal.md
+++ b/notes/journal.md
@@ -2,6 +2,8 @@
 
 Things to remember to do soon:
 
+*   Revise Value per Yandros' style comments here:
+    https://users.rust-lang.org/t/lazy-initialization-vs-interior-mutability/30742/7
 *   Revise the parsing code to use iterator subtraction to extract slices, rather than
     building up small strings a character at a time.
     *   https://users.rust-lang.org/t/takewhile-iterator-over-chars-to-string-slice/11014
@@ -49,7 +51,9 @@ Things to remember to do soon:
         indices.  The code no longer uses `as_str` at all.  The `chars` iterator is
         recreated only on `backup`.  I don't think there's any reason not to use a
         `Peekable<Chars>` at this point.
-
+    *   CharStar now uses a `Peekable<Char>` and provides `peek()`.  Also, the token
+        methods return `Option<&str>` so that they can return `None` when there's no token
+        instead of `""`.
 
 ### 2019-08-10 (Saturday)
 *   Returning data_rep as `Ref<T>`.

--- a/notes/journal.md
+++ b/notes/journal.md
@@ -75,7 +75,7 @@ set a {a b ;c d}
 # Prints only a and b
 foreach item $a {puts $item}
 ```
-            *   Wrote Issue #43.
+            *   Wrote Issue #43. (Now fixed.)
         *   next_is
             *   Use char_ptr's `is`
         *   at_end
@@ -84,6 +84,7 @@ foreach item $a {puts $item}
             *   Like char_ptr's `skip`, but with assertion that we're skipping what
                 we expected to skip.
             *   Can add it if it seems necessary.
+*   At this point, I think Tokenizer is ready for the list conversion.
 
 
 ### 2019-08-10 (Saturday)


### PR DESCRIPTION
This pull request adds a new type, Tokenizer, which allows a string slice to be parsed into slices while still supporting "peek()", and uses it in the list-syntax parser.  Tokenizer will eventually replace CharPtr and EvalPtr.