### PR TITLE
Fix Issue 56: test harness result code

### DIFF
--- a/molt-app/Cargo.toml
+++ b/molt-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "molt-app"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Will Duquette <will@wjduquette.com>"]
 edition = "2018"
 description = "Molt Shell Application"
@@ -11,8 +11,8 @@ readme = "README.md"
 keywords = ["language", "script", "scripting", "tcl"]
 
 [dependencies]
-molt = { version = "0.1.0", path = "../molt" }
-molt-shell = { version = "0.1.0", path = "../molt-shell" }
+molt = { version = "0.2.0", path = "../molt" }
+molt-shell = { version = "0.2.0", path = "../molt-shell" }
 
 [[bin]]
 name = "moltsh"

--- a/molt-app/src/main.rs
+++ b/molt-app/src/main.rs
@@ -27,7 +27,11 @@ fn main() {
                 }
             }
             "test" => {
-                molt_shell::test_harness(&mut interp, &args[2..]);
+                if molt_shell::test_harness(&mut interp, &args[2..]).is_ok() {
+                    std::process::exit(0);
+                } else {
+                    std::process::exit(1);
+                }
             }
             "help" => {
                 print_help();

--- a/molt-shell/Cargo.toml
+++ b/molt-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "molt-shell"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Will Duquette <will@wjduquette.com>"]
 edition = "2018"
 description = "Molt Application Frameworks"
@@ -11,5 +11,5 @@ readme = "README.md"
 keywords = ["language", "script", "scripting", "tcl"]
 
 [dependencies]
-molt = { version = "0.1.0", path = "../molt" }
+molt = { version = "0.2.0", path = "../molt" }
 rustyline = "5.0.0"

--- a/molt/Cargo.toml
+++ b/molt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "molt"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Will Duquette <will@wjduquette.com>"]
 edition = "2018"
 description = "Embeddable TCL interpreter for Rust applications"


### PR DESCRIPTION
This commit fixes issue #56.

`molt_shell::test_harness` now returns a `Result<(),()>`, `Ok` if there were no errors or test failures and `Err` otherwise.

molt_app tests this and exits with code 0 on Ok and code 1 on error.

Also, bumped the version to 0.2.0 since the change to `test_harness` can break code.