### PR TITLE
Legacy Parser Cleanup

### DIFF
--- a/molt/src/expr.rs
+++ b/molt/src/expr.rs
@@ -865,7 +865,7 @@ fn expr_lex(interp: &mut Interp, info: &mut ExprInfo) -> DatumResult {
         Some('[') => {
             let mut ctx = EvalPtr::from_tokenizer(&p);
             ctx.set_no_eval(info.no_eval > 0);
-            let script_val = interp.parse_script(&mut ctx)?;
+            let script_val = interp.parse_and_eval_script(&mut ctx)?;
             info.token = VALUE;
             info.expr = ctx.to_tokenizer();
             if info.no_eval > 0 {
@@ -877,7 +877,7 @@ fn expr_lex(interp: &mut Interp, info: &mut ExprInfo) -> DatumResult {
         Some('"') => {
             let mut ctx = EvalPtr::from_tokenizer(&p);
             ctx.set_no_eval(info.no_eval > 0);
-            let val = interp.parse_quoted_word(&mut ctx)?;
+            let val = interp.parse_and_eval_quoted_word(&mut ctx)?;
             info.token = VALUE;
             info.expr = ctx.to_tokenizer();
             if info.no_eval > 0 {
@@ -891,7 +891,7 @@ fn expr_lex(interp: &mut Interp, info: &mut ExprInfo) -> DatumResult {
         Some('{') => {
             let mut ctx = EvalPtr::from_tokenizer(&p);
             ctx.set_no_eval(info.no_eval > 0);
-            let val = eval_braced_word(&mut ctx)?;
+            let val = parse_and_eval_braced_word(&mut ctx)?;
             info.token = VALUE;
             info.expr = ctx.to_tokenizer();
             if info.no_eval > 0 {
@@ -1098,7 +1098,7 @@ fn expr_lex(interp: &mut Interp, info: &mut ExprInfo) -> DatumResult {
 }
 
 /// Parses a braced word, returning a Value.
-fn eval_braced_word(ctx: &mut EvalPtr) -> MoltResult {
+fn parse_and_eval_braced_word(ctx: &mut EvalPtr) -> MoltResult {
     if let Word::Value(val) = parser::parse_braced_word(ctx)? {
         Ok(val)
     } else {

--- a/molt/src/expr.rs
+++ b/molt/src/expr.rs
@@ -853,7 +853,7 @@ fn expr_lex(interp: &mut Interp, info: &mut ExprInfo) -> DatumResult {
         Some('$') => {
             let mut ctx = EvalPtr::from_tokenizer(&p);
             ctx.set_no_eval(info.no_eval > 0);
-            let var_val = interp.parse_variable(&mut ctx)?;
+            let var_val = parse_and_eval_variable(interp, &mut ctx)?;
             info.token = VALUE;
             info.expr = ctx.to_tokenizer();
             if info.no_eval > 0 {
@@ -1097,6 +1097,26 @@ fn expr_lex(interp: &mut Interp, info: &mut ExprInfo) -> DatumResult {
     }
 }
 
+// Parses a variable reference.  A bare "$" is an error.
+fn parse_and_eval_variable(interp: &mut Interp, ctx: &mut EvalPtr) -> MoltResult {
+    // FIRST, skip the '$'
+    ctx.skip_char('$');
+
+    // NEXT, make sure this is really a variable reference.
+    if !ctx.next_is_varname_char() && !ctx.next_is('{') {
+        return molt_err!("invalid character \"$\"");
+    }
+
+    // NEXT, get the variable reference.
+    let word = parser::parse_varname(ctx)?;
+
+    if ctx.is_no_eval() {
+        Ok(Value::empty())
+    } else {
+        interp.eval_word(&word)
+    }
+}
+
 /// Parses and evaluates an interpolated script in Molt input, i.e., a string beginning with
 /// a "[", returning a MoltResult.  If the no_eval flag is set, returns an empty value.
 /// This is used to handled interpolated scripts in expressions.
@@ -1141,7 +1161,6 @@ fn parse_and_eval_quoted_word(interp: &mut Interp, ctx: &mut EvalPtr) -> MoltRes
         interp.eval_word(&word)
     }
 }
-
 
 /// Parses a braced word, returning a Value.
 fn parse_and_eval_braced_word(ctx: &mut EvalPtr) -> MoltResult {

--- a/molt/src/expr.rs
+++ b/molt/src/expr.rs
@@ -6,6 +6,7 @@
 use crate::eval_ptr::EvalPtr;
 use crate::interp::Interp;
 use crate::list;
+use crate::parser::Word;
 use crate::tokenizer::Tokenizer;
 use crate::*;
 
@@ -890,7 +891,7 @@ fn expr_lex(interp: &mut Interp, info: &mut ExprInfo) -> DatumResult {
         Some('{') => {
             let mut ctx = EvalPtr::from_tokenizer(&p);
             ctx.set_no_eval(info.no_eval > 0);
-            let val = interp.parse_braced_word(&mut ctx)?;
+            let val = eval_braced_word(&mut ctx)?;
             info.token = VALUE;
             info.expr = ctx.to_tokenizer();
             if info.no_eval > 0 {
@@ -1093,6 +1094,15 @@ fn expr_lex(interp: &mut Interp, info: &mut ExprInfo) -> DatumResult {
             info.token = UNKNOWN;
             Ok(Datum::none())
         }
+    }
+}
+
+/// Parses a braced word, returning a Value.
+fn eval_braced_word(ctx: &mut EvalPtr) -> MoltResult {
+    if let Word::Value(val) = parser::parse_braced_word(ctx)? {
+        Ok(val)
+    } else {
+        unreachable!()
     }
 }
 

--- a/molt/src/expr.rs
+++ b/molt/src/expr.rs
@@ -877,7 +877,7 @@ fn expr_lex(interp: &mut Interp, info: &mut ExprInfo) -> DatumResult {
         Some('"') => {
             let mut ctx = EvalPtr::from_tokenizer(&p);
             ctx.set_no_eval(info.no_eval > 0);
-            let val = interp.parse_and_eval_quoted_word(&mut ctx)?;
+            let val = parse_and_eval_quoted_word(interp, &mut ctx)?;
             info.token = VALUE;
             info.expr = ctx.to_tokenizer();
             if info.no_eval > 0 {
@@ -1127,6 +1127,19 @@ fn parse_and_eval_script(interp: &mut Interp, ctx: &mut EvalPtr) -> MoltResult {
     }
 
     result
+}
+
+/// Parses and evaluates a quoted word in Molt input, i.e., a string beginning with
+/// a double quote, returning a MoltResult.  If the no_eval flag is set, returns an empty
+/// value.  This is used to handle double-quoted strings in expressions.
+fn parse_and_eval_quoted_word(interp: &mut Interp, ctx: &mut EvalPtr) -> MoltResult {
+    let word = parser::parse_quoted_word(ctx)?;
+
+    if ctx.is_no_eval() {
+        Ok(Value::empty())
+    } else {
+        interp.eval_word(&word)
+    }
 }
 
 

--- a/molt/src/interp.rs
+++ b/molt/src/interp.rs
@@ -889,14 +889,6 @@ impl Interp {
     // And then it should get moved to `expr` until `expr` is revised to parse
     // to an internal form as well.
 
-    pub(crate) fn parse_braced_word(&mut self, ctx: &mut EvalPtr) -> MoltResult {
-        if let Word::Value(val) = parser::parse_braced_word(ctx)? {
-            Ok(val)
-        } else {
-            unreachable!()
-        }
-    }
-
     /// Parse a quoted word.
     pub(crate) fn parse_quoted_word(&mut self, ctx: &mut EvalPtr) -> MoltResult {
         // FIRST, consume the the opening quote.
@@ -1337,40 +1329,6 @@ mod tests {
                 "unknown math function \"a\""
             )))
         );
-    }
-
-    #[test]
-    fn test_parse_braced_word() {
-        let mut interp = Interp::new();
-
-        // Simple string
-        assert_eq!(pbrace(&mut interp, "{abc}"), "abc|".to_string());
-
-        // Simple string with following space
-        assert_eq!(pbrace(&mut interp, "{abc} "), "abc| ".to_string());
-
-        // String with white space
-        assert_eq!(pbrace(&mut interp, "{a b c} "), "a b c| ".to_string());
-
-        // String with $ and []space
-        assert_eq!(pbrace(&mut interp, "{a $b [c]} "), "a $b [c]| ".to_string());
-
-        // String with escaped braces
-        assert_eq!(pbrace(&mut interp, "{a\\{bc} "), "a\\{bc| ".to_string());
-        assert_eq!(pbrace(&mut interp, "{ab\\}c} "), "ab\\}c| ".to_string());
-
-        // String with escaped newline (a real newline with a \ in front)
-        assert_eq!(pbrace(&mut interp, "{ab\\\nc}"), "ab c|".to_string());
-    }
-
-    fn pbrace(interp: &mut Interp, input: &str) -> String {
-        let mut ctx = EvalPtr::new(input);
-
-        match interp.parse_braced_word(&mut ctx) {
-            Ok(val) => format!("{}|{}", val.as_str(), ctx.tok().as_str()),
-            Err(ResultCode::Error(value)) => format!("{}", value),
-            Err(code) => format!("{:?}", code),
-        }
     }
 
     #[test]

--- a/molt/src/interp.rs
+++ b/molt/src/interp.rs
@@ -889,14 +889,14 @@ impl Interp {
     // is revised to separate parsing from evaluation, these routines may become
     // unnecessary.
 
+    // Parses a variable reference.  A bare "$" is an error.
     pub(crate) fn parse_variable(&mut self, ctx: &mut EvalPtr) -> MoltResult {
         // FIRST, skip the '$'
         ctx.skip_char('$');
 
-        // NEXT, make sure this is really a variable reference.  If it isn't
-        // just return a "$".
+        // NEXT, make sure this is really a variable reference.
         if !ctx.next_is_varname_char() && !ctx.next_is('{') {
-            return Ok(Value::from("$"));
+            return molt_err!("invalid character \"$\"");
         }
 
         // NEXT, is this a braced variable name?
@@ -1273,7 +1273,8 @@ mod tests {
         assert_eq!(pvar(&mut interp, "a", "$a.bc"), "OK|.bc".to_string());
         assert_eq!(pvar(&mut interp, "a1_", "$a1_.bc"), "OK|.bc".to_string());
         assert_eq!(pvar(&mut interp, "a", "${a}b"), "OK|b".to_string());
-        assert_eq!(pvar(&mut interp, "a", "$"), "$|".to_string());
+        assert_eq!(pvar(&mut interp, "a", "$"),
+            "invalid character \"$\"".to_string());
 
         assert_eq!(
             pvar(&mut interp, "a", "$1"),

--- a/molt/src/interp.rs
+++ b/molt/src/interp.rs
@@ -395,7 +395,8 @@ impl Interp {
     }
 
     // Evals a parsed Script, producing a normal MoltResult.
-    fn eval_script(&mut self, script: &Script) -> MoltResult {
+    // Also used by expr.rs.
+    pub(crate) fn eval_script(&mut self, script: &Script) -> MoltResult {
         let mut result_value = Value::empty();
 
         for word_vec in script.commands() {
@@ -887,38 +888,6 @@ impl Interp {
     // routines are used only by the Molt expression evaluator.  When the expression evaluator
     // is revised to separate parsing from evaluation, these routines may become
     // unnecessary.
-
-    /// Parses and evaluates an interpolated script in Molt input, i.e., a string beginning with
-    /// a "[", returning a MoltResult.  If the no_eval flag is set, returns an empty value.
-    /// This is used to handled interpolated scripts in expressions.
-    pub(crate) fn parse_and_eval_script(&mut self, ctx: &mut EvalPtr) -> MoltResult {
-        // FIRST, skip the '['
-        ctx.skip_char('[');
-
-        // NEXT, parse the script up to the matching ']'
-        let old_flag = ctx.is_bracket_term();
-        ctx.set_bracket_term(true);
-
-        let script = parser::parse_script(ctx)?;
-        let result = if ctx.is_no_eval() {
-            Ok(Value::empty())
-        } else {
-            self.eval_script(&script)
-        };
-
-        ctx.set_bracket_term(old_flag);
-
-        // NEXT, make sure there's a closing bracket
-        if result.is_ok() {
-            if ctx.next_is(']') {
-                ctx.next();
-            } else {
-                return molt_err!("missing close-bracket");
-            }
-        }
-
-        result
-    }
 
     /// Parses and evaluates a quoted word in Molt input, i.e., a string beginning with
     /// a double quote, returning a MoltResult.  If the no_eval flag is set, returns an empty

--- a/molt/src/interp.rs
+++ b/molt/src/interp.rs
@@ -444,8 +444,8 @@ impl Interp {
         Ok(list)
     }
 
-    // Evaluates a single word.
-    fn eval_word(&mut self, word: &Word) -> MoltResult {
+    // Evaluates a single word.  This is also used by expr.rs.
+    pub(crate) fn eval_word(&mut self, word: &Word) -> MoltResult {
         match word {
             Word::Value(val) => Ok(val.clone()),
             Word::VarRef(name) => self.var(name),
@@ -888,20 +888,6 @@ impl Interp {
     // routines are used only by the Molt expression evaluator.  When the expression evaluator
     // is revised to separate parsing from evaluation, these routines may become
     // unnecessary.
-
-    /// Parses and evaluates a quoted word in Molt input, i.e., a string beginning with
-    /// a double quote, returning a MoltResult.  If the no_eval flag is set, returns an empty
-    /// value.  This is used to handle double-quoted strings in expressions.
-    pub(crate) fn parse_and_eval_quoted_word(&mut self, ctx: &mut EvalPtr) -> MoltResult {
-        let word = parser::parse_quoted_word(ctx)?;
-
-        if ctx.is_no_eval() {
-            Ok(Value::empty())
-        } else {
-            self.eval_word(&word)
-        }
-    }
-
 
     pub(crate) fn parse_variable(&mut self, ctx: &mut EvalPtr) -> MoltResult {
         // FIRST, skip the '$'

--- a/molt/src/parser.rs
+++ b/molt/src/parser.rs
@@ -303,12 +303,12 @@ fn parse_dollar(ctx: &mut EvalPtr, tokens: &mut Tokens) -> Result<(), ResultCode
     } else {
         tokens.push(parse_varname(ctx)?);
     }
-    
+
     Ok(())
 }
 
-/// Parses a variable name; the "$" has already been consumed.
-fn parse_varname(ctx: &mut EvalPtr) -> Result<Word, ResultCode> {
+/// Parses a variable name; the "$" has already been consumed.  Also used by expr.rs.
+pub(crate) fn parse_varname(ctx: &mut EvalPtr) -> Result<Word, ResultCode> {
     // FIRST, is this a braced variable name?
     let var_name;
 
@@ -331,7 +331,6 @@ fn parse_varname(ctx: &mut EvalPtr) -> Result<Word, ResultCode> {
 
     Ok(Word::VarRef(var_name))
 }
-
 
 struct Tokens {
     list: Vec<Word>,

--- a/molt/src/parser.rs
+++ b/molt/src/parser.rs
@@ -187,7 +187,7 @@ pub(crate) fn parse_braced_word(ctx: &mut EvalPtr) -> Result<Word, ResultCode> {
 }
 
 /// Parse a quoted word.
-fn parse_quoted_word(ctx: &mut EvalPtr) -> Result<Word, ResultCode> {
+pub(crate) fn parse_quoted_word(ctx: &mut EvalPtr) -> Result<Word, ResultCode> {
     // FIRST, consume the the opening quote.
     ctx.next();
 

--- a/molt/src/parser.rs
+++ b/molt/src/parser.rs
@@ -300,10 +300,16 @@ fn parse_dollar(ctx: &mut EvalPtr, tokens: &mut Tokens) -> Result<(), ResultCode
     // just return a "$".
     if !ctx.next_is_varname_char() && !ctx.next_is('{') {
         tokens.push_char('$');
-        return Ok(());
+    } else {
+        tokens.push(parse_varname(ctx)?);
     }
+    
+    Ok(())
+}
 
-    // NEXT, is this a braced variable name?
+/// Parses a variable name; the "$" has already been consumed.
+fn parse_varname(ctx: &mut EvalPtr) -> Result<Word, ResultCode> {
+    // FIRST, is this a braced variable name?
     let var_name;
 
     if ctx.next_is('{') {
@@ -323,9 +329,9 @@ fn parse_dollar(ctx: &mut EvalPtr, tokens: &mut Tokens) -> Result<(), ResultCode
         var_name = ctx.token(start).to_string();
     }
 
-    tokens.push(Word::VarRef(var_name));
-    Ok(())
+    Ok(Word::VarRef(var_name))
 }
+
 
 struct Tokens {
     list: Vec<Word>,

--- a/molt/src/parser.rs
+++ b/molt/src/parser.rs
@@ -207,7 +207,7 @@ pub(crate) fn parse_quoted_word(ctx: &mut EvalPtr) -> Result<Word, ResultCode> {
             if start != ctx.mark() {
                 tokens.push_str(ctx.token(start));
             }
-            parse_varname(ctx, &mut tokens)?;
+            parse_dollar(ctx, &mut tokens)?;
             start = ctx.mark();
         } else if ctx.next_is('\\') {
             if start != ctx.mark() {
@@ -250,7 +250,7 @@ fn parse_bare_word(ctx: &mut EvalPtr) -> Result<Word, ResultCode> {
             if start != ctx.mark() {
                 tokens.push_str(ctx.token(start));
             }
-            parse_varname(ctx, &mut tokens)?;
+            parse_dollar(ctx, &mut tokens)?;
             start = ctx.mark();
         } else if ctx.next_is('\\') {
             if start != ctx.mark() {
@@ -292,7 +292,7 @@ fn parse_brackets(ctx: &mut EvalPtr) -> Result<Script, ResultCode> {
     result
 }
 
-fn parse_varname(ctx: &mut EvalPtr, tokens: &mut Tokens) -> Result<(), ResultCode> {
+fn parse_dollar(ctx: &mut EvalPtr, tokens: &mut Tokens) -> Result<(), ResultCode> {
     // FIRST, skip the '$'
     ctx.skip_char('$');
 
@@ -782,7 +782,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_varname() {
+    fn test_parse_dollar() {
         // Normal var names
         assert_eq!(pvar("$a"), Ok((Word::VarRef("a".into()), "".into())));
         assert_eq!(pvar("$abc"), Ok((Word::VarRef("abc".into()), "".into())));
@@ -808,7 +808,7 @@ mod tests {
     fn pvar(input: &str) -> Result<(Word, String), ResultCode> {
         let mut ctx = EvalPtr::new(input);
         let mut tokens = Tokens::new();
-        parse_varname(&mut ctx, &mut tokens)?;
+        parse_dollar(&mut ctx, &mut tokens)?;
         Ok((tokens.take(), ctx.tok().as_str().to_string()))
     }
 }

--- a/molt/src/parser.rs
+++ b/molt/src/parser.rs
@@ -129,7 +129,7 @@ fn parse_next_word(ctx: &mut EvalPtr) -> Result<Word, ResultCode> {
     }
 }
 
-fn parse_braced_word(ctx: &mut EvalPtr) -> Result<Word, ResultCode> {
+pub(crate) fn parse_braced_word(ctx: &mut EvalPtr) -> Result<Word, ResultCode> {
     // FIRST, skip the opening brace, and count it; non-escaped braces need to
     // balance.
     ctx.skip_char('{');


### PR DESCRIPTION
For a little while now, Molt has had two TCL parsers, one that parses to an internal form for later evaluation, and one that parses and evaluates in one step.  The latter was only used by the expression parser for interpolated TCL code.  This pull request moves the remains of the legacy parser to `expr.rs`, and revises it to parse using the new parser before evaluating. 