### PR TITLE
Subcommand dispatch

### DIFF
--- a/molt/src/commands.rs
+++ b/molt/src/commands.rs
@@ -33,10 +33,7 @@ pub fn cmd_append(interp: &mut Interp, _: ContextID, argv: &[Value]) -> MoltResu
 
 /// # array *subcommand* ?*arg*...?
 pub fn cmd_array(interp: &mut Interp, context_id: ContextID, argv: &[Value]) -> MoltResult {
-    check_args(1, argv, 2, 0, "subcommand ?arg ...?")?;
-    let subc = Subcommand::find(&ARRAY_SUBCOMMANDS, argv[1].as_str())?;
-
-    (subc.1)(interp, context_id, argv)
+    interp.call_subcommand(context_id, argv, 1, &ARRAY_SUBCOMMANDS)
 }
 
 const ARRAY_SUBCOMMANDS: [Subcommand; 6] = [
@@ -441,10 +438,7 @@ pub fn cmd_incr(interp: &mut Interp, _: ContextID, argv: &[Value]) -> MoltResult
 
 /// # info *subcommand* ?*arg*...?
 pub fn cmd_info(interp: &mut Interp, context_id: ContextID, argv: &[Value]) -> MoltResult {
-    check_args(1, argv, 2, 0, "subcommand ?arg ...?")?;
-    let subc = Subcommand::find(&INFO_SUBCOMMANDS, argv[1].as_str())?;
-
-    (subc.1)(interp, context_id, argv)
+    interp.call_subcommand(context_id, argv, 1, &INFO_SUBCOMMANDS)
 }
 
 const INFO_SUBCOMMANDS: [Subcommand; 3] = [

--- a/molt/src/interp.rs
+++ b/molt/src/interp.rs
@@ -1106,7 +1106,6 @@ impl Interp {
         }
     }
 
-
     /// Retrieves the value of the named scalar variable in the current scope.
     ///
     /// Returns an error if the variable is not found, or if the variable is an array variable.
@@ -1180,7 +1179,6 @@ impl Interp {
         self.scopes.set(name, value.clone())?;
         Ok(value)
     }
-
 
     /// Retrieves the value of the named array element in the current scope.
     ///


### PR DESCRIPTION
This pull request adds the `Interp::call_subcommand` method, and updates the `info` and `array` commands to use it.  It also completes the `interp.rs` doc comment scrub.