### PR TITLE
Add new string subcommands

### DIFF
--- a/molt/src/commands.rs
+++ b/molt/src/commands.rs
@@ -1128,22 +1128,20 @@ pub fn cmd_string_first(_interp: &mut Interp, _: ContextID, argv: &[Value]) -> M
     let needle = argv[2].as_str();
     let haystack = argv[3].as_str();
 
-    let mut start = if argv.len() == 5 {
-        argv[4].as_int()?
+    let start: usize = if argv.len() == 5 {
+        let arg = argv[4].as_int()?;
+
+        if arg < 0 { 0 } else { arg as usize }
     } else {
         0
     };
 
-    if start < 0 {
-        start = 0;
-    }
-
-    let pos = if start as usize >= haystack.len() {
+    let pos = if start >= haystack.len() {
         -1
     } else {
-        haystack[start as usize..]
+        haystack[start..]
             .find(needle)
-            .map(|x| x as MoltInt + start)
+            .map(|x| (x + start) as MoltInt)
             .unwrap_or(-1)
     };
 

--- a/molt/src/commands.rs
+++ b/molt/src/commands.rs
@@ -1128,13 +1128,17 @@ pub fn cmd_string_first(_interp: &mut Interp, _: ContextID, argv: &[Value]) -> M
     let needle = argv[2].as_str();
     let haystack = argv[3].as_str();
 
-    let start = if argv.len() == 5 {
+    let mut start = if argv.len() == 5 {
         argv[4].as_int()?
     } else {
         0
     };
 
-    let pos = if start < 0 || start as usize >= haystack.len() {
+    if start < 0 {
+        start = 0;
+    }
+
+    let pos = if start as usize >= haystack.len() {
         -1
     } else {
         haystack[start as usize..]

--- a/molt/src/commands.rs
+++ b/molt/src/commands.rs
@@ -1000,7 +1000,7 @@ pub fn cmd_string(interp: &mut Interp, context_id: ContextID, argv: &[Value]) ->
     interp.call_subcommand(context_id, argv, 1, &STRING_SUBCOMMANDS)
 }
 
-const STRING_SUBCOMMANDS: [Subcommand; 11] = [
+const STRING_SUBCOMMANDS: [Subcommand; 12] = [
     Subcommand("cat", cmd_string_cat),
     Subcommand("compare", cmd_string_compare),
     Subcommand("equal", cmd_string_equal),
@@ -1008,7 +1008,7 @@ const STRING_SUBCOMMANDS: [Subcommand; 11] = [
     // Subcommand("index", cmd_string_todo),
     Subcommand("last", cmd_string_last),
     Subcommand("length", cmd_string_length),
-    // Subcommand("map", cmd_string_todo),
+    Subcommand("map", cmd_string_map),
     // Subcommand("range", cmd_string_todo),
     // Subcommand("replace", cmd_string_todo),
     // Subcommand("repeat", cmd_string_todo),
@@ -1187,6 +1187,76 @@ pub fn cmd_string_length(_interp: &mut Interp, _: ContextID, argv: &[Value]) -> 
 
     let len: MoltInt = argv[2].as_str().chars().count() as MoltInt;
     molt_ok!(len)
+}
+
+/// string map ?-nocase? *charMap* *string*
+pub fn cmd_string_map(_interp: &mut Interp, _: ContextID, argv: &[Value]) -> MoltResult {
+    check_args(2, argv, 4, 5, "?-nocase? charMap string")?;
+
+    let mut nocase = false;
+
+    if argv.len() == 5 {
+        let opt = argv[2].as_str();
+
+        if opt == "-nocase" {
+            nocase = true;
+        } else {
+            return molt_err!("bad option \"{}\": must be -nocase", opt);
+        }
+    }
+
+    let char_map = argv[argv.len() - 2].as_dict()?;
+    let string = argv[argv.len() - 1].as_str();
+
+    let filtered_keys = char_map
+        .iter()
+        .map(|(k, v)| {
+            let new_k = if nocase {
+                Value::from(k.as_str().to_lowercase())
+            } else {
+                k.clone()
+            };
+
+            let count = new_k.as_str().chars().count();
+
+            (new_k, count, v.clone())
+        })
+        .filter(|(_, count, _)| *count > 0)
+        .collect::<Vec<_>>();
+    let matching_string = if nocase {
+        string.to_lowercase()
+    } else {
+        string.to_string()
+    };
+
+    let mut result = "".to_string();
+    let mut skip = 0;
+
+    for (i, c) in string.char_indices() {
+        if skip > 0 {
+            skip -= 1;
+            continue;
+        }
+
+        let mut matched = false;
+
+        for (from, from_char_count, to) in &filtered_keys {
+            if matching_string[i..].starts_with(&from.as_str()) {
+                matched = true;
+
+                result.push_str(to.as_str());
+                skip = from_char_count - 1;
+
+                break;
+            }
+        }
+
+        if !matched {
+            result.push(c);
+        }
+    }
+
+    molt_ok!(result)
 }
 
 /// string tolower *string*

--- a/molt/src/commands.rs
+++ b/molt/src/commands.rs
@@ -1000,11 +1000,11 @@ pub fn cmd_string(interp: &mut Interp, context_id: ContextID, argv: &[Value]) ->
     interp.call_subcommand(context_id, argv, 1, &STRING_SUBCOMMANDS)
 }
 
-const STRING_SUBCOMMANDS: [Subcommand; 6] = [
+const STRING_SUBCOMMANDS: [Subcommand; 7] = [
     Subcommand("cat", cmd_string_cat),
     Subcommand("compare", cmd_string_compare),
     Subcommand("equal", cmd_string_equal),
-    // Subcommand("first", cmd_string_todo),
+    Subcommand("first", cmd_string_first),
     // Subcommand("index", cmd_string_todo),
     // Subcommand("last", cmd_string_todo),
     Subcommand("length", cmd_string_length),
@@ -1119,6 +1119,31 @@ pub fn cmd_string_equal(_interp: &mut Interp, _: ContextID, argv: &[Value]) -> M
         let flag = util::compare_len(argv[arglen - 2].as_str(), argv[arglen - 1].as_str(), length)? == 0;
         molt_ok!(flag)
     }
+}
+
+/// string first *needleString* *haystackString* ?*startIndex*?
+pub fn cmd_string_first(_interp: &mut Interp, _: ContextID, argv: &[Value]) -> MoltResult {
+    check_args(2, argv, 4, 5, "needleString haystackString ?startIndex?")?;
+
+    let needle = argv[2].as_str();
+    let haystack = argv[3].as_str();
+
+    let start = if argv.len() == 5 {
+        argv[4].as_int()?
+    } else {
+        0
+    };
+
+    let pos = if start < 0 || start as usize >= haystack.len() {
+        -1
+    } else {
+        haystack[start as usize..]
+            .find(needle)
+            .map(|x| x as MoltInt + start)
+            .unwrap_or(-1)
+    };
+
+    molt_ok!(pos)
 }
 
 /// string length *string*

--- a/molt/src/commands.rs
+++ b/molt/src/commands.rs
@@ -1000,7 +1000,7 @@ pub fn cmd_string(interp: &mut Interp, context_id: ContextID, argv: &[Value]) ->
     interp.call_subcommand(context_id, argv, 1, &STRING_SUBCOMMANDS)
 }
 
-const STRING_SUBCOMMANDS: [Subcommand; 7] = [
+const STRING_SUBCOMMANDS: [Subcommand; 10] = [
     Subcommand("cat", cmd_string_cat),
     Subcommand("compare", cmd_string_compare),
     Subcommand("equal", cmd_string_equal),
@@ -1015,9 +1015,9 @@ const STRING_SUBCOMMANDS: [Subcommand; 7] = [
     // Subcommand("reverse", cmd_string_todo),
     Subcommand("tolower", cmd_string_tolower),
     Subcommand("toupper", cmd_string_toupper),
-    // Subcommand("trim", cmd_string_todo),
-    // Subcommand("trimleft", cmd_string_todo),
-    // Subcommand("trimright", cmd_string_todo),
+    Subcommand("trim", cmd_string_trim),
+    Subcommand("trimleft", cmd_string_trim),
+    Subcommand("trimright", cmd_string_trim),
 ];
 
 /// Temporary: stub for string subcommands.
@@ -1168,6 +1168,20 @@ pub fn cmd_string_toupper(_interp: &mut Interp, _: ContextID, argv: &[Value]) ->
 
     let upper = argv[2].as_str().to_uppercase();
     molt_ok!(upper)
+}
+
+/// string (trim|trimleft|trimright) *string*
+pub fn cmd_string_trim(_interp: &mut Interp, _: ContextID, argv: &[Value]) -> MoltResult {
+    check_args(2, argv, 3, 3, "string")?;
+
+    let s = argv[2].as_str();
+    let trimmed = match argv[1].as_str() {
+        "trimleft" => s.trim_start(),
+        "trimright" => s.trim_end(),
+        _ => s.trim(),
+    };
+
+    molt_ok!(trimmed)
 }
 
 /// throw *type* *message*

--- a/molt/src/commands.rs
+++ b/molt/src/commands.rs
@@ -1230,7 +1230,7 @@ pub fn cmd_string_map(_interp: &mut Interp, _: ContextID, argv: &[Value]) -> Mol
         None
     };
 
-    let mut result = "".to_string();
+    let mut result = String::new();
     let mut skip = 0;
 
     for (i, c) in string.char_indices() {

--- a/molt/src/commands.rs
+++ b/molt/src/commands.rs
@@ -1223,10 +1223,11 @@ pub fn cmd_string_map(_interp: &mut Interp, _: ContextID, argv: &[Value]) -> Mol
         })
         .filter(|(_, count, _)| *count > 0)
         .collect::<Vec<_>>();
-    let matching_string = if nocase {
-        string.to_lowercase()
+
+    let string_lower: Option<String> = if nocase {
+        Some(string.to_lowercase())
     } else {
-        string.to_string()
+        None
     };
 
     let mut result = "".to_string();
@@ -1241,7 +1242,12 @@ pub fn cmd_string_map(_interp: &mut Interp, _: ContextID, argv: &[Value]) -> Mol
         let mut matched = false;
 
         for (from, from_char_count, to) in &filtered_keys {
-            if matching_string[i..].starts_with(&from.as_str()) {
+            let haystack: &str = match &string_lower {
+                Some(x) => &x[i..],
+                None => &string[i..],
+            };
+
+            if haystack.starts_with(&from.as_str()) {
                 matched = true;
 
                 result.push_str(to.as_str());

--- a/molt/src/commands.rs
+++ b/molt/src/commands.rs
@@ -1000,13 +1000,13 @@ pub fn cmd_string(interp: &mut Interp, context_id: ContextID, argv: &[Value]) ->
     interp.call_subcommand(context_id, argv, 1, &STRING_SUBCOMMANDS)
 }
 
-const STRING_SUBCOMMANDS: [Subcommand; 10] = [
+const STRING_SUBCOMMANDS: [Subcommand; 11] = [
     Subcommand("cat", cmd_string_cat),
     Subcommand("compare", cmd_string_compare),
     Subcommand("equal", cmd_string_equal),
     Subcommand("first", cmd_string_first),
     // Subcommand("index", cmd_string_todo),
-    // Subcommand("last", cmd_string_todo),
+    Subcommand("last", cmd_string_last),
     Subcommand("length", cmd_string_length),
     // Subcommand("map", cmd_string_todo),
     // Subcommand("range", cmd_string_todo),
@@ -1145,6 +1145,39 @@ pub fn cmd_string_first(_interp: &mut Interp, _: ContextID, argv: &[Value]) -> M
             .find(needle)
             .map(|x| x as MoltInt + start)
             .unwrap_or(-1)
+    };
+
+    molt_ok!(pos)
+}
+
+/// string last *needleString* *haystackString* ?*lastIndex*?
+pub fn cmd_string_last(_interp: &mut Interp, _: ContextID, argv: &[Value]) -> MoltResult {
+    check_args(2, argv, 4, 5, "needleString haystackString ?lastIndex?")?;
+
+    let needle = argv[2].as_str();
+    let haystack = argv[3].as_str();
+
+    let last: Option<usize> = if argv.len() == 5 {
+        let arg = argv[4].as_int()?;
+
+        if arg < 0 {
+            None
+        } else if arg as usize >= haystack.len() {
+            Some(haystack.len() - 1)
+        } else {
+            Some(arg as usize)
+        }
+    } else {
+        Some(haystack.len() - 1)
+    };
+
+    let pos = match last {
+        Some(offset) =>
+            haystack[..=offset]
+                .rfind(needle)
+                .map(|x| x as MoltInt)
+                .unwrap_or(-1),
+        None => -1,
     };
 
     molt_ok!(pos)

--- a/molt/src/commands.rs
+++ b/molt/src/commands.rs
@@ -1000,7 +1000,7 @@ pub fn cmd_string(interp: &mut Interp, context_id: ContextID, argv: &[Value]) ->
     interp.call_subcommand(context_id, argv, 1, &STRING_SUBCOMMANDS)
 }
 
-const STRING_SUBCOMMANDS: [Subcommand; 12] = [
+const STRING_SUBCOMMANDS: [Subcommand; 13] = [
     Subcommand("cat", cmd_string_cat),
     Subcommand("compare", cmd_string_compare),
     Subcommand("equal", cmd_string_equal),
@@ -1009,7 +1009,7 @@ const STRING_SUBCOMMANDS: [Subcommand; 12] = [
     Subcommand("last", cmd_string_last),
     Subcommand("length", cmd_string_length),
     Subcommand("map", cmd_string_map),
-    // Subcommand("range", cmd_string_todo),
+    Subcommand("range", cmd_string_range),
     // Subcommand("replace", cmd_string_todo),
     // Subcommand("repeat", cmd_string_todo),
     // Subcommand("reverse", cmd_string_todo),
@@ -1263,6 +1263,34 @@ pub fn cmd_string_map(_interp: &mut Interp, _: ContextID, argv: &[Value]) -> Mol
     }
 
     molt_ok!(result)
+}
+
+/// string range *string* *first* *last*
+pub fn cmd_string_range(_interp: &mut Interp, _: ContextID, argv: &[Value]) -> MoltResult {
+    check_args(2, argv, 5, 5, "string first last")?;
+
+    let string = argv[2].as_str();
+    let first = argv[3].as_int()?;
+    let last = argv[4].as_int()?;
+
+    if last < 0 {
+        return molt_ok!("");
+    }
+
+    let clamp = { |i: MoltInt| if i < 0 {
+            0
+        } else {
+            i
+        }
+    };
+
+    let substr = string
+        .chars()
+        .skip(clamp(first) as usize)
+        .take((clamp(last) - clamp(first) + 1) as usize)
+        .collect::<String>();
+
+    molt_ok!(substr)
 }
 
 /// string tolower *string*

--- a/molt/src/commands.rs
+++ b/molt/src/commands.rs
@@ -1000,7 +1000,7 @@ pub fn cmd_string(interp: &mut Interp, context_id: ContextID, argv: &[Value]) ->
     interp.call_subcommand(context_id, argv, 1, &STRING_SUBCOMMANDS)
 }
 
-const STRING_SUBCOMMANDS: [Subcommand; 4] = [
+const STRING_SUBCOMMANDS: [Subcommand; 6] = [
     Subcommand("cat", cmd_string_cat),
     Subcommand("compare", cmd_string_compare),
     Subcommand("equal", cmd_string_equal),
@@ -1013,8 +1013,8 @@ const STRING_SUBCOMMANDS: [Subcommand; 4] = [
     // Subcommand("replace", cmd_string_todo),
     // Subcommand("repeat", cmd_string_todo),
     // Subcommand("reverse", cmd_string_todo),
-    // Subcommand("tolower", cmd_string_todo),
-    // Subcommand("toupper", cmd_string_todo),
+    Subcommand("tolower", cmd_string_tolower),
+    Subcommand("toupper", cmd_string_toupper),
     // Subcommand("trim", cmd_string_todo),
     // Subcommand("trimleft", cmd_string_todo),
     // Subcommand("trimright", cmd_string_todo),
@@ -1127,6 +1127,22 @@ pub fn cmd_string_length(_interp: &mut Interp, _: ContextID, argv: &[Value]) -> 
 
     let len: MoltInt = argv[2].as_str().chars().count() as MoltInt;
     molt_ok!(len)
+}
+
+/// string tolower *string*
+pub fn cmd_string_tolower(_interp: &mut Interp, _: ContextID, argv: &[Value]) -> MoltResult {
+    check_args(2, argv, 3, 3, "string")?;
+
+    let lower = argv[2].as_str().to_lowercase();
+    molt_ok!(lower)
+}
+
+/// string toupper *string*
+pub fn cmd_string_toupper(_interp: &mut Interp, _: ContextID, argv: &[Value]) -> MoltResult {
+    check_args(2, argv, 3, 3, "string")?;
+
+    let upper = argv[2].as_str().to_uppercase();
+    molt_ok!(upper)
 }
 
 /// throw *type* *message*

--- a/molt/tests/string.tcl
+++ b/molt/tests/string.tcl
@@ -104,7 +104,7 @@ test string-9.2 {string first} {
     string first a foobarbaz
 } -ok 4
 
-test string-9.3 {string first:} {
+test string-9.3 {string first} {
     string first zoom foobarbaz
 } -ok -1
 
@@ -126,7 +126,7 @@ test string-9.7 {string first: startIndex} {
 
 test string-9.8 {string first: negative startIndex} {
     string first bar foobarbaz -99
-} -ok -1
+} -ok 3
 
 test string-9.9 {string first: startIndex beyond string end} {
     list \

--- a/molt/tests/string.tcl
+++ b/molt/tests/string.tcl
@@ -300,3 +300,44 @@ test string-14.18 {string map: Unicode 2} {
 test string-14.19 {string map: deletion} {
     string map {0 {} 3 {}} 22233322
 } -ok 22222
+
+# string range
+test string-15.1 {string range: basic} {
+    string range 012345 1 3
+} -ok 123
+
+test string-15.2 {string range: first > last} {
+    string range 012345 1 0
+} -ok {}
+
+test string-15.4 {string range: negative} {
+    string range abcdefg -10 -5
+} -ok {}
+
+test string-15.5 {string range: negative first > last} {
+    string range abcdefg -5 -10
+} -ok {}
+
+test string-15.6 {string range: negative first} {
+    string range 012345 -2 1
+} -ok 01
+
+test string-15.7 {string range: last > len} {
+    string range 012345 0 99
+} -ok 012345
+
+test string-15.8 {string range: negative first, last > len} {
+    string range 012345 -99 99
+} -ok 012345
+
+test string-15.9 {string range: first > len, last > len} {
+    string range 012345 99 99
+} -ok {}
+
+test string-15.10 {string range: Unicode 1} {
+    string range _аб_в 1 2
+} -ok аб
+
+test string-15.11 {string range: Unicode 2} {
+    string range カタカナ 2 3
+} -ok カナ

--- a/molt/tests/string.tcl
+++ b/molt/tests/string.tcl
@@ -228,6 +228,18 @@ test string-13.10 {string last: non-numerical lastIndex} {
     string last a abc NOT_A_NUMBER
 } -error {expected integer but got "NOT_A_NUMBER"}
 
+test string-13.11 {string last: startIndex with Unicode 1} {
+    string last б абв 1
+} -ok 1
+
+test string-13.12 {string last: startIndex with Unicode 2} {
+    list \
+        [string last тест _____тест__ 7] \
+        [string last тест _____тест__ 8] \
+        [string last тест _____тест__ 9] \
+        [string last тест _____тест__ 99]
+} -ok {-1 5 5 5}
+
 # string map
 test string-14.1 {string map} {
     string map {FOO BAR} abcdFOOefgh

--- a/molt/tests/string.tcl
+++ b/molt/tests/string.tcl
@@ -139,6 +139,10 @@ test string-9.10 {string first: non-numerical startIndex} {
     string first a abc NOT_A_NUMBER
 } -error {expected integer but got "NOT_A_NUMBER"}
 
+test string-9.11 {string first: startIndex with Unicode} {
+    string first б абв 1
+} -ok 1
+
 # string trim
 test string-10.1 {string trim: empty} {
     string trim {}

--- a/molt/tests/string.tcl
+++ b/molt/tests/string.tcl
@@ -68,3 +68,29 @@ test string-7.2 {string lengths} {
         [string length ab] \
         [string length abc]
 } -ok {0 1 2 3}
+
+# string tolower
+test string-8.1 {string tolower: blank} {
+    string tolower {}
+} -ok {}
+
+test string-8.2 {string tolower: ASCII} {
+    string tolower {ASCII TEXT 0123456789}
+} -ok {ascii text 0123456789}
+
+test string-8.3 {string tolower: Unicode} {
+    string tolower МАРС
+} -ok марс
+
+# string toupper
+test string-8.1 {string toupper: blank} {
+    string toupper {}
+} -ok {}
+
+test string-8.2 {string toupper: ASCII} {
+    string toupper {ascii text 0123456789}
+} -ok {ASCII TEXT 0123456789}
+
+test string-8.3 {string toupper: Unicode} {
+    string toupper венера
+} -ok ВЕНЕРА

--- a/molt/tests/string.tcl
+++ b/molt/tests/string.tcl
@@ -138,3 +138,42 @@ test string-9.9 {string first: startIndex beyond string end} {
 test string-9.10 {string first: non-numerical startIndex} {
     string first a abc NOT_A_NUMBER
 } -error {expected integer but got "NOT_A_NUMBER"}
+
+# string trim
+test string-10.1 {string trim: empty} {
+    string trim {}
+} -ok {}
+
+test string-10.2 {string trim: nothing to trim} {
+    string trim {hello world}
+} -ok {hello world}
+
+test string-10.3 {string trim: whitespace to trim} {
+    string trim "    \n\t hello \n\tworld   \t\n   "
+} -ok "hello \n\tworld"
+
+# string trimleft
+test string-11.1 {string trimleft: empty} {
+    string trimleft {}
+} -ok {}
+
+test string-11.2 {string trimleft: nothing to trim} {
+    string trimleft {hello world}
+} -ok {hello world}
+
+test string-11.3 {string trimleft: whitespace to trim} {
+    string trimleft "    \n\t hello \n\tworld   \t\n   "
+} -ok "hello \n\tworld   \t\n   "
+
+# string trimright
+test string-12.1 {string trimright: empty} {
+    string trimright {}
+} -ok {}
+
+test string-12.2 {string trimright: nothing to trim} {
+    string trimright {hello world}
+} -ok {hello world}
+
+test string-12.3 {string trimright: whitespace to trim} {
+    string trimright "    \n\t hello \n\tworld   \t\n   "
+} -ok "    \n\t hello \n\tworld"

--- a/molt/tests/string.tcl
+++ b/molt/tests/string.tcl
@@ -177,3 +177,49 @@ test string-12.2 {string trimright: nothing to trim} {
 test string-12.3 {string trimright: whitespace to trim} {
     string trimright "    \n\t hello \n\tworld   \t\n   "
 } -ok "    \n\t hello \n\tworld"
+
+# string last
+test string-13.1 {string last} {
+    string last foo foobarbaz
+} -ok 0
+
+test string-13.2 {string last} {
+    string last a foobarbaz
+} -ok 7
+
+test string-13.3 {string last} {
+    string last zoom foobarbaz
+} -ok -1
+
+test string-13.4 {string last} {
+    string last bar foobarbaz
+} -ok 3
+
+test string-13.5 {string last} {
+    string last bazz foobarbaz
+} -ok -1
+
+test string-13.6 {string last: lastIndex} {
+    string last bar foobarbaz 3
+} -ok -1
+
+test string-13.7 {string last: lastIndex} {
+    string last bar foobarbaz 5
+} -ok 3
+
+test string-13.8 {string last: zeno and negative lastIndex} {
+    list \
+        [string last f foobarbaz 0] \
+        [string last f foobarbaz -99]
+} -ok {0 -1}
+
+test string-13.9 {string last: lastIndex beyond string end} {
+    list \
+        [string last z foobarbaz 7] \
+        [string last z foobarbaz 9] \
+        [string last z foobarbaz 99]
+} -ok {-1 8 8}
+
+test string-13.10 {string last: non-numerical lastIndex} {
+    string last a abc NOT_A_NUMBER
+} -error {expected integer but got "NOT_A_NUMBER"}

--- a/molt/tests/string.tcl
+++ b/molt/tests/string.tcl
@@ -94,3 +94,47 @@ test string-8.2 {string toupper: ASCII} {
 test string-8.3 {string toupper: Unicode} {
     string toupper венера
 } -ok ВЕНЕРА
+
+# string first
+test string-9.1 {string first} {
+    string first foo foobarbaz
+} -ok 0
+
+test string-9.2 {string first} {
+    string first a foobarbaz
+} -ok 4
+
+test string-9.3 {string first:} {
+    string first zoom foobarbaz
+} -ok -1
+
+test string-9.4 {string first} {
+    string first bar foobarbaz
+} -ok 3
+
+test string-9.5 {string first} {
+    string first bazz foobarbaz
+} -ok -1
+
+test string-9.6 {string first: startIndex} {
+    string first bar foobarbaz 3
+} -ok 3
+
+test string-9.7 {string first: startIndex} {
+    string first bar foobarbaz 5
+} -ok -1
+
+test string-9.8 {string first: negative startIndex} {
+    string first bar foobarbaz -99
+} -ok -1
+
+test string-9.9 {string first: startIndex beyond string end} {
+    list \
+        [string first z foobarbaz 9] \
+        [string first z foobarbaz 10] \
+        [string first z foobarbaz 99]
+} -ok {-1 -1 -1}
+
+test string-9.10 {string first: non-numerical startIndex} {
+    string first a abc NOT_A_NUMBER
+} -error {expected integer but got "NOT_A_NUMBER"}

--- a/molt/tests/string.tcl
+++ b/molt/tests/string.tcl
@@ -223,3 +223,80 @@ test string-13.9 {string last: lastIndex beyond string end} {
 test string-13.10 {string last: non-numerical lastIndex} {
     string last a abc NOT_A_NUMBER
 } -error {expected integer but got "NOT_A_NUMBER"}
+
+# string map
+test string-14.1 {string map} {
+    string map {FOO BAR} abcdFOOefgh
+} -ok abcdBARefgh
+
+test string-14.2 {string map: -nocase} {
+   string map -nocase {foo BAR EF __} abcdFOOefgh
+} -ok abcdBAR__gh
+
+test string-14.3 {string map} {
+    string map {a b} aaaaa
+} -ok bbbbb
+
+test string-14.4 {string map} {
+    string map {a b c d X {}} XabcbaX
+} -ok bbdbb
+
+test string-14.5 {string map: bad list} {
+    string map {a b c} abcba
+} -error {missing value to go with key}
+
+test string-14.6 {string map: no match} {
+    string map {foo bar} f
+} -ok f
+
+test string-14.7 {string map} {
+    string map {foo bar} fo
+} -ok fo
+
+test string-14.8 {string map} {
+    string map {a b eh ha e f} aehaeheee
+} -ok bhabhafff
+
+test string-14.9 {string map} {
+    string map {s longer} xsx
+} -ok xlongerx
+
+test string-14.10 {string map} {
+    string map {quite_long shorter} this_is_quite_long
+} -ok this_is_shorter
+
+test string-14.11 {string map: empty map} {
+    string map {{} {}} hello
+} -ok hello
+
+test string-14.12 {string map: empty map 2} {
+    string map {{} { }} hello
+} -ok hello
+
+test string-14.13 {string map: no multiple replacement} {
+    string map {foo bar bar baz} foo
+} -ok bar
+
+test string-14.14 {string map: no multiple replacement 2} {
+    string map {foo bar ba xx x z o 0} foo
+} -ok bar
+
+test string-14.15 {string map: no multiple replacement 3} {
+    string map {abc 1 ab 2 a 3 1 0} 1abcaababcabababc
+} -ok 01321221
+
+test string-14.16 {string map: shorter match masks longer} {
+    string map {1 0 ab 2 a 3 abc 1} 1abcaababcabababc
+} -ok 02c322c222c
+
+test string-14.17 {string map: Unicode 1} {
+    string map {カ ka タ ta ナ na} カタカナ
+} -ok katakana
+
+test string-14.18 {string map: Unicode 2} {
+    string map {а a б b в v} _аб_в_
+} -ok _ab_v_
+
+test string-14.19 {string map: deletion} {
+    string map {0 {} 3 {}} 22233322
+} -ok 22222


### PR DESCRIPTION
In this PR I have implemented the following `string` subcommands:
* `string tolower`, `string toupper`
* `string first`, `string last`
* `string trim`, `string trimleft`, `string trimright`
* `string map`
* `string range`

I have added over 60 tests for them in total.  I didn't make any changes to the Molt Book.  Should contributors do that?  The implementation of `string map` seems a little ugly.  I am not sure how to improve it.

Resolved issues: #75, #77, #79, #80, #84, #85, #86.