### PR TITLE
Turn Datum into an enum

### DIFF
--- a/molt/src/expr.rs
+++ b/molt/src/expr.rs
@@ -1251,20 +1251,8 @@ fn expr_looks_like_int<'a>(ptr: &Tokenizer<'a>) -> bool {
 fn expr_abs_func(args: &[Datum; MAX_MATH_ARGS]) -> DatumResult {
     match args[0] {
         Datum::String(..) => molt_err!("argument to math function didn't have numeric value"),
-        Datum::Float(v) => {
-            if v < 0.0 {
-                Ok(Datum::Float(-v))
-            } else {
-                Ok(Datum::Float(v))
-            }
-        }
-        Datum::Int(v) => {
-            if v < 0 {
-                Ok(Datum::Int(-v))
-            } else {
-                Ok(Datum::Int(v))
-            }
-        }
+        Datum::Float(v) => Ok(Datum::Float(v.abs())),
+        Datum::Int(v) => Ok(Datum::Int(v.abs())),
     }
 }
 

--- a/molt/src/expr.rs
+++ b/molt/src/expr.rs
@@ -536,17 +536,8 @@ fn expr_get_value<'a>(interp: &mut Interp, info: &'a mut ExprInfo, prec: i32) ->
                 let v1 = assert_int(operator, &value)?;
                 let v2 = assert_int(operator, &value2)?;
 
-                // The following code is a bit tricky:  it ensures that
-                // right shifts propagate the sign bit even on machines
-                // where ">>" won't do it by default.
-                // WHD: Not sure if this is an issue in Rust.
-
                 // TODO: Use checked_shr
-                value = if v1 < 0 {
-                    Datum::Int(!((!v1) >> v2))
-                } else {
-                    Datum::Int(v1 >> v2)
-                }
+                value = Datum::Int(v1 >> v2)
             }
             LESS => {
                 value = match coerce_pair(operator, &value, &value2)? {


### PR DESCRIPTION
Hi Will -- it's Jonathan! This weekend, I'm making good on my years-old promise to check out Molt. Feel free to take or leave the changes in this PR; I had an idea to try out and it seems to have worked fairly nicely, but it's up to your discretion in the end.

This PR turns the existing `struct Datum` into a more Rust-y `enum Datum`, and propagates those changes throughout `expr.rs`. In the process, I ended up unifying the type coercion sections for each operator with their respective evaluation sections. I especially noticed an inconsistency between the assumptions made by execution for `AND` and `OR` and what the respective coercion was doing; I think the approach in this PR scopes the relevant assumptions much more tightly, so it'll be much more difficult for things to get out of sync like that.

This PR also contains minor contributions for the shift-right operator and absolute value function, which can both be simplified by using core Rust functionality. (Yes, as an arithmetic shift, `>>` is guaranteed to preserve sign!)

Lastly, I ran `rustfmt` on my changes to keep things consistent. I find some of the formatting choices it made to be less readable, but I defer to convention :)